### PR TITLE
Refine test quality review approach and fix mutex unwrap issues

### DIFF
--- a/.claude/commands/checklist.md
+++ b/.claude/commands/checklist.md
@@ -25,6 +25,20 @@ We're about to close this session and lose anything not captured that we might n
 - [ ] All documents follow size limits (flag documents >300 lines)
 - [ ] **Obsolete content archived** (not just deleted)
 
+### Git Workflow
+- [ ] All changes committed with clear, descriptive messages
+- [ ] Branch pushed to remote (`git push -u origin [branch-name]`)
+- [ ] Pull request created (or ready to create)
+- [ ] PR description includes:
+  - [ ] Summary of changes made
+  - [ ] Testing performed and results
+  - [ ] Related issue/task numbers
+  - [ ] Breaking changes noted (if any)
+  - [ ] Screenshots/examples (if UI changes)
+- [ ] CI/CD checks passing (or failures explained/expected)
+- [ ] Ready for code review
+- [ ] Reviewers assigned or requested
+
 ### Discovery Triggers Met?
 Review `/discoveries/triggers.md` - did any of these happen without documentation?
 - [ ] Spent >5 minutes figuring out how something works

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -22,6 +22,39 @@ Before starting ANY implementation:
 
 ## Implementation Process
 
+### Phase 0: Git Setup (If on main branch)
+
+Before starting ANY implementation work:
+
+1. **Check Current Branch**
+   ```bash
+   git branch --show-current
+   ```
+
+2. **Create Feature Branch (if on main)**
+   ```bash
+   # Branch naming conventions:
+   # feat/[task-name] - New features
+   # fix/[issue-name] - Bug fixes  
+   # refactor/[component] - Code refactoring
+   # docs/[section] - Documentation updates
+   # test/[component] - Test additions/fixes
+   
+   git checkout -b feat/[descriptive-task-name]
+   ```
+
+3. **Verify Clean Working Tree**
+   ```bash
+   git status
+   ```
+
+4. **Pull Latest Changes (if needed)**
+   ```bash
+   git pull origin main
+   ```
+
+**⚠️ NEVER implement directly on main branch** - Always use feature branches for proper code review workflow.
+
 ### Phase 1: Setup & Validation
 
 1. **Locate Planning Documents**
@@ -209,6 +242,13 @@ Before writing ANY implementation code, ensure:
 - **What**: [Brief description of what was implemented]
 - **Why**: [Business/technical reason]
 - **How**: [High-level approach taken]
+
+### Git Information
+- **Branch**: [branch-name]
+- **Commits**: [number of commits made]
+- **Files changed**: [count]
+- **Ready for PR**: Yes/No
+- **PR Title Suggestion**: [title based on task]
 
 ### Changes Made
 

--- a/.claude/commands/review-tests.md
+++ b/.claude/commands/review-tests.md
@@ -19,10 +19,19 @@ Parse $ARGUMENTS for options:
 ## Primary Review Focus
 
 ### 1. Tautological Tests Detection
-- Look for tests that assert the same value they just set
-- Find tests that only verify mocked behavior without testing real logic
-- Identify tests like: `expect(true).toBe(true)` or `expect(mockFn).toHaveBeenCalled()` after directly calling mockFn
-- Check for tests that pass even when the implementation is broken
+**IMPORTANT**: Distinguish between legitimate mock testing and true tautologies.
+
+**TRUE TAUTOLOGIES (Bad)**:
+- Tests that assert the same value they just set without any logic
+- Tests that only verify hardcoded mock return values without testing conditional behavior
+- Tests like: `expect(true).toBe(true)` or direct constructor assignment verification
+- Tests that pass even when all business logic is removed
+
+**LEGITIMATE MOCK TESTING (Good)**:
+- Tests that exercise conditional logic in mocks (if/else, match statements, error handling)
+- Tests that verify different code paths based on mock return values
+- Tests that validate state-dependent behavior using mocks
+- Tests where mocks enable testing all branches of the unit under test
 
 ### 2. Proper Mocking and Isolation
 - Ensure external dependencies are mocked (databases, APIs, file systems)
@@ -63,26 +72,44 @@ Parse $ARGUMENTS for options:
 
 3. **Common Anti-Patterns to Flag:**
 
-   **Direct Tautologies:**
+   **Direct Tautologies (Bad):**
    ```javascript
-   // BAD - Testing the assignment
+   // BAD - Testing the assignment without any logic
    const result = 5;
    expect(result).toBe(5);
    ```
 
-   **Mock-Only Tests:**
+   **Hardcoded Mock Return Tests (Bad):**
    ```javascript
-   // BAD - Testing the mock, not the component
+   // BAD - Only verifying hardcoded mock values
    mockService.getValue.mockReturnValue(42);
    const result = component.getData();
-   expect(result).toBe(42);
+   expect(result).toBe(42); // No conditional logic tested
    ```
 
-   **Self-Referential Tests:**
+   **Constructor Assignment Tests (Bad):**
    ```javascript
    // BAD - Just testing constructor assignment
    const user = new User({ name: 'John' });
-   expect(user.name).toBe('John');
+   expect(user.name).toBe('John'); // No business logic
+   ```
+
+   **Legitimate Mock Testing (Good):**
+   ```rust
+   // GOOD - Testing conditional logic in mock
+   let mut agent = MockAgent::new("test");
+   let result = agent.execute(request).await;
+   assert!(result.is_err()); // Tests state validation logic
+   ```
+
+   **Good Branching Tests:**
+   ```rust
+   // GOOD - Testing different code paths
+   if message.contains("unsafe") {
+       assert!(!validator.validate(unsafe_msg).approved);
+   } else {
+       assert!(validator.validate(safe_msg).approved);
+   }
    ```
 
    **Missing Isolation:**

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,11 @@
       "Bash(cargo fmt:*)",
       "Bash(find:*)",
       "Bash(TZ='America/Chicago' date)",
-      "Bash(sed:*)"
+      "Bash(sed:*)",
+      "Bash(git checkout:*)",
+      "Bash(grep:*)",
+      "Bash(cargo:*)",
+      "Bash(git add:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,9 @@
       "Bash(gh run view:*)",
       "Bash(git commit:*)",
       "Bash(git push:*)",
-      "Bash(gh run list:*)"
+      "Bash(gh run list:*)",
+      "Bash(chmod:*)",
+      "Bash(./scripts/ci-local.sh:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,9 @@
       "Bash(git checkout:*)",
       "Bash(grep:*)",
       "Bash(cargo:*)",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(gh run view:*)",
+      "Bash(git commit:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,9 @@
       "Bash(cargo:*)",
       "Bash(git add:*)",
       "Bash(gh run view:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(gh run list:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,7 +19,8 @@
       "Bash(git push:*)",
       "Bash(gh run list:*)",
       "Bash(chmod:*)",
-      "Bash(./scripts/ci-local.sh:*)"
+      "Bash(./scripts/ci-local.sh:*)",
+      "Bash(gh pr view:*)"
     ],
     "deny": [],
     "ask": []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,18 @@ description = "Self-improving AI agent framework built on Rust with type-safe ab
 thiserror.workspace = true
 anyhow.workspace = true
 
+# Core trait dependencies
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+uuid = { version = "1.11", features = ["v4", "serde"] }
+chrono = { version = "0.4", features = ["serde"] }
+tower.workspace = true
+
 [dev-dependencies]
 criterion.workspace = true
 proptest.workspace = true
+tokio.workspace = true
 tokio-test.workspace = true
 
 [features]

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ cargo clippy
 
 # Format code
 cargo fmt
+
+# Run all CI checks locally (recommended before pushing)
+./scripts/ci-local.sh
 ```
 
 #### Development

--- a/context-network/discovery/2025-08-19-001-tautological-vs-mock-testing.md
+++ b/context-network/discovery/2025-08-19-001-tautological-vs-mock-testing.md
@@ -1,0 +1,164 @@
+# Discovery Record: Distinguishing Tautological Tests from Legitimate Mock Testing
+
+## Discovery Context
+- **Date:** 2025-08-19
+- **Task:** Apply test review recommendations and fix tautological tests
+- **Discoverer:** Development Team
+- **Session Context:** Continuing from previous test quality review
+
+## What Was Discovered
+
+### Critical Misunderstanding: Mock Testing vs Tautological Tests
+**Found:** Initial confusion between legitimate mock-based testing and true tautologies
+**Location:** Throughout `src/traits/*.rs` test modules
+**Problem:** Nearly reverted legitimate tests that exercise conditional logic in mocks
+**Resolution:** Clear distinction established between problematic and valid patterns
+
+### True Tautological Test Pattern
+**Found:** Test that only verified hardcoded mock return values
+**Location:** `src/traits/mod.rs:141-155` (`agent_available_tools_list`)
+**Example BEFORE:**
+```rust
+#[tokio::test]
+async fn agent_available_tools_list() {
+    let agent = MockAgent::new("test-agent");
+    let tools = agent.available_tools();
+    
+    // TAUTOLOGICAL: Just testing hardcoded mock return
+    assert_eq!(tools, vec!["mock-tool"]);
+}
+```
+
+**Example AFTER:**
+```rust
+#[tokio::test] 
+async fn agent_available_tools_list() {
+    let agent = MockAgent::new("test-agent");
+    let tools = agent.available_tools();
+    
+    // Test that agent provides tools list (contract requirement)
+    assert!(!tools.is_empty(), "Agent should have available tools");
+    // Test that all tool names are valid (non-empty strings)
+    for tool in &tools {
+        assert!(!tool.is_empty(), "Tool names should not be empty");
+        assert!(!tool.chars().all(|c| c.is_whitespace()), "Tool names should not be only whitespace");
+    }
+    // Test that tools list is deterministic (same agent returns same tools)
+    let tools2 = agent.available_tools();
+    assert_eq!(tools, tools2, "available_tools() should be deterministic");
+}
+```
+
+### Legitimate Mock Testing Patterns
+**Found:** Tests that exercise conditional logic in mocks are valid and necessary
+**Examples:**
+- `validator.validate()` tests that exercise if/else logic based on message content
+- `agent.execute()` tests that validate state-dependent behavior
+- `tool.execute()` tests that handle parameter validation with branching logic
+
+## Significance
+
+### Immediate Impact
+- **Prevented Bad Refactor:** Stopped removal of legitimate tests that provide real value
+- **Clarified Testing Philosophy:** Established that mocking dependencies is appropriate in TDD
+- **Quality Improvement:** Fixed one true tautological test while preserving good tests
+
+### Architectural Implications
+- Mock-based testing is fundamental to TDD approach
+- Every line of code should have tests proving it works when conditions are met
+- Mocks enable testing all branches of conditional logic without requiring real implementations
+
+### Process Insights
+- Test review commands need precise criteria to avoid false positives
+- "Tautological" label must be applied carefully - most mock tests are legitimate
+- Code review processes need clear examples of good vs bad patterns
+
+## Reusable Patterns Discovered
+
+### TRUE TAUTOLOGIES (Bad)
+1. **Hardcoded Mock Returns:** Tests that only verify static mock return values without conditional logic
+2. **Constructor Assignment:** Tests that verify field assignment without business rules
+3. **Round-trip Serialization:** Tests that only verify serialize/deserialize without data validation
+
+### LEGITIMATE MOCK TESTING (Good)  
+1. **Conditional Logic Exercise:** Tests that trigger different code paths in mocks
+2. **State Validation:** Tests that verify different behavior based on mock state
+3. **Error Path Testing:** Tests that exercise error handling using mocked failures
+4. **Contract Enforcement:** Tests that validate interface requirements using mocks
+
+### Review Command Improvement Pattern
+Updated `/review-tests` command with:
+- Clear distinction between legitimate and problematic patterns
+- Rust-specific examples of good branching tests
+- Emphasis on conditional logic vs hardcoded returns
+
+## Implementation Evidence
+
+### Updated Review Command Pattern:
+```markdown
+**TRUE TAUTOLOGIES (Bad)**:
+- Tests that only verify hardcoded mock return values without testing conditional behavior
+
+**LEGITIMATE MOCK TESTING (Good)**:  
+- Tests that exercise conditional logic in mocks (if/else, match statements, error handling)
+- Tests that verify different code paths based on mock return values
+```
+
+### Fixed Test Pattern:
+```rust
+// GOOD: Tests contract requirements and business rules
+assert!(!tools.is_empty(), "Agent should have available tools");
+for tool in &tools {
+    assert!(!tool.is_empty(), "Tool names should not be empty");
+}
+```
+
+## Cross-Domain Connections
+
+### Relationship to TDD Philosophy
+- Mocking is essential for testing units in isolation
+- Every line of code needs tests, including conditional logic in mocks
+- Red-Green-Refactor cycle depends on proper mock-based unit testing
+
+### Relationship to Error System Quality
+- High-quality error tests use both mocks and real implementations appropriately
+- Mock-based testing enables comprehensive error path coverage
+- Property-based testing complements mock testing for edge cases
+
+### Relationship to Test Quality Framework
+- Refined criteria for identifying true test quality issues
+- Balanced approach: improve bad tests without removing good ones
+- Evidence-based assessment rather than pattern-matching
+
+## Future Applications
+
+### Immediate Use Cases
+- Apply refined criteria to remaining test quality reviews
+- Use updated `/review-tests` command for consistent assessments
+- Train team on legitimate mock testing vs tautological patterns
+
+### Prevention Strategies
+- Clear examples in code review guidelines
+- Automated linting rules for true tautologies only
+- Template tests showing good mock-based patterns
+
+### Knowledge Transfer
+- Document legitimate mock testing patterns for team
+- Share refined test quality criteria in development standards
+- Establish examples library for reference during reviews
+
+## Related Discoveries
+- **Builds On:** 2025-01-18-001-test-quality-patterns.md - Initial test quality framework
+- **Refines:** Test quality assessment criteria with better precision
+- **Enables:** More accurate test reviews without false positives
+
+## Validation Status
+- **Tested:** All changes verified with passing test suite (cargo test)
+- **Reviewed:** Command improvements validated through usage
+- **Documented:** Patterns captured in updated review command and this record
+
+## Next Steps
+1. Apply refined criteria to remaining test files systematically
+2. Create examples library of good mock testing patterns
+3. Update team guidelines with legitimate vs tautological distinctions
+4. Establish more precise automated detection for true tautologies only

--- a/context-network/planning/groomed_foundational_backlog.md
+++ b/context-network/planning/groomed_foundational_backlog.md
@@ -1,19 +1,55 @@
 # Groomed Task Backlog - Early Low-Level Foundational Tasks
 *Generated: 2025-01-18*
+*Updated: 2025-08-18 (US Central)*
+
+## ✅ Completed Tasks
+
+### 0. Setup Project Structure ✅
+**Status**: **COMPLETED** - Project workspace structure is established
+**One-liner**: Create Cargo workspace with initial crate structure and development tooling
+**Completed Files**:
+- ✅ `Cargo.toml` (workspace root with full configuration)
+- ✅ `src/lib.rs` (main library with prelude module) 
+- ✅ `.gitignore` (standard Rust gitignore)
+- ✅ `rust-toolchain.toml` (Rust 1.80 stable)
+- ✅ `README.md` (project documentation)
+- ✅ All development dependencies configured
+- ✅ Project compiles successfully with `cargo check`
+
+### 1. Create Core Error Type Hierarchy ✅
+**Status**: **COMPLETED** - Full error system implemented with recovery strategies
+**One-liner**: Establish the foundational error system with recovery strategies for all Patinox components
+**Completed Implementation**:
+- ✅ `PatinoxError` enum with Validation, Execution, Network, Configuration categories
+- ✅ All error types implement `std::error::Error` trait chain correctly
+- ✅ `recovery_strategy()` method with comprehensive `RecoveryStrategy` enum
+- ✅ Error context preserved through the chain with `thiserror` integration
+- ✅ `anyhow` integration for application-level usage
+- ✅ Complete documentation with examples in `src/error.rs`
+- ✅ Comprehensive TDD test suite with property-based tests
+- ✅ All tests passing, all error types are Send + Sync
+
+### 2. Define Core Trait Interfaces ✅
+**Status**: **COMPLETED** - All core trait interfaces implemented with comprehensive tests
+**One-liner**: Create the fundamental `Agent`, `Tool`, `Validator`, and `Monitor` traits that form Patinox's architecture
+**Completed Implementation**:
+- ✅ `Agent` trait with lifecycle methods (start, stop, execute) and health checking
+- ✅ `Tool` trait with async execution and JSON schema parameters 
+- ✅ `Validator` trait with async validation (object-safe design)
+- ✅ `Monitor` trait with telemetry hooks and event collection
+- ✅ All traits are object-safe (`Box<dyn Trait>` compiles correctly)
+- ✅ All traits support `Send + Sync` for multi-threading
+- ✅ Comprehensive documentation with usage examples
+- ✅ Mock implementations for testing all scenarios
+- ✅ Full integration with error types from task #1
+- ✅ 85 comprehensive tests covering all trait functionality
 
 ## 🚀 Ready for Implementation
 
-### 0. Setup Project Structure
-**One-liner**: Create Cargo workspace with initial crate structure and development tooling
-**Sequence**: Absolute first - nothing else can be done without this
-**Files to create**:
-- `Cargo.toml` (workspace root)
-- `patinox-core/Cargo.toml` 
-- `patinox-core/src/lib.rs`
-- `.gitignore`
-- `rust-toolchain.toml`
-- `.github/workflows/ci.yml` (basic)
-- `README.md` (minimal)
+### NEXT: 3. Implement Type Safety Infrastructure
+**One-liner**: Build typestate patterns and builder patterns for compile-time safety
+**Sequence**: Next priority - can be done in parallel with #4, depends on completed traits (#2)
+**Status**: **READY TO START** - All dependencies met
 
 <details>
 <summary>Full Implementation Details</summary>

--- a/context-network/planning/refactoring_task_extract_common_test_utilities.md
+++ b/context-network/planning/refactoring_task_extract_common_test_utilities.md
@@ -1,0 +1,99 @@
+# Task: Extract Common Test Utilities
+
+**Created**: 2025-08-18 22:36 CDT
+**Status**: Planned (deferred from code review recommendations)
+**Priority**: Medium
+**Category**: Code Quality / Technical Debt
+
+## Overview
+
+Extract common test utilities and patterns to reduce code duplication across trait test modules. This refactoring will improve maintainability and consistency of test code.
+
+## Context
+
+During code review of Core Trait Interfaces implementation, multiple instances of test code duplication were identified:
+
+- Mock implementations appear in multiple files with similar patterns
+- Test helper functions are duplicated across trait modules
+- Similar assertion patterns could be extracted into utilities
+- Common test setup code could be centralized
+
+## Current State
+
+Test files with duplication:
+- `src/traits/mod.rs` (656 lines) - Contains mock implementations for all traits
+- `src/traits/agent.rs` (438 lines) - TestAgent mock implementation
+- `src/traits/validator.rs` (457 lines) - TestValidator mock implementation  
+- `src/traits/monitor.rs` (633 lines) - TestMonitor mock implementation
+- `src/traits/tool.rs` (353 lines) - TestTool mock implementation
+
+## Refactoring Tasks
+
+### 1. Create Common Test Module Structure
+- [ ] Create `src/traits/testing/` module
+- [ ] Create `src/traits/testing/mocks.rs` for mock implementations
+- [ ] Create `src/traits/testing/utilities.rs` for test helpers
+- [ ] Create `src/traits/testing/mod.rs` for module organization
+
+### 2. Extract Mock Implementations
+- [ ] Move MockAgent from `agent.rs` to `mocks.rs`
+- [ ] Move MockTool from `tool.rs` to `mocks.rs`
+- [ ] Move MockValidator from `validator.rs` to `mocks.rs`
+- [ ] Move MockMonitor from `monitor.rs` to `mocks.rs`
+- [ ] Update all test imports to use centralized mocks
+
+### 3. Extract Common Test Patterns
+- [ ] Extract UUID generation helpers
+- [ ] Extract common assertion patterns for Result types
+- [ ] Extract test data builders (request/response builders)
+- [ ] Extract serialization test helpers
+- [ ] Extract object safety test patterns
+
+### 4. Standardize Test Organization
+- [ ] Group tests by functionality rather than mixing unit/integration
+- [ ] Standardize test naming conventions
+- [ ] Ensure consistent test documentation
+- [ ] Apply consistent error handling patterns in tests
+
+## Benefits
+
+- **Reduced Duplication**: Eliminate repeated mock implementations
+- **Consistency**: Standardized test patterns across all trait modules
+- **Maintainability**: Single location for test utilities makes updates easier
+- **Readability**: Shorter test files focused on trait-specific behavior
+- **Reusability**: Common patterns can be used for future trait implementations
+
+## Implementation Notes
+
+- Keep trait-specific test logic in original files
+- Only extract truly common/reusable patterns
+- Maintain test coverage during refactoring
+- Consider using conditional compilation (`#[cfg(test)]`) for test-only code
+- Ensure mock implementations remain realistic and useful
+
+## Estimated Effort
+
+**Size**: Medium (affects multiple files but straightforward extraction)
+**Timeline**: 2-3 hours
+**Risk**: Low (mostly moving existing working code)
+
+## Dependencies
+
+- No external dependencies
+- Should be done after current implementation phase stabilizes
+- Can be done incrementally per trait module
+
+## Success Criteria
+
+- [ ] All existing tests continue to pass
+- [ ] Test code duplication reduced by >50%
+- [ ] Mock implementations centralized and consistent
+- [ ] Test utilities are well-documented
+- [ ] No regression in test coverage
+- [ ] Test files are more focused and readable
+
+## Related Context
+
+- Code review findings from Core Trait Interfaces implementation
+- Test quality assessment patterns from discovery records
+- Alignment with Rust testing best practices

--- a/context-network/planning/refactoring_task_improve_test_error_consistency.md
+++ b/context-network/planning/refactoring_task_improve_test_error_consistency.md
@@ -1,0 +1,249 @@
+# Task: Improve Test Error Handling Consistency
+
+**Created**: 2025-08-18 22:36 CDT
+**Status**: Planned (deferred from code review recommendations)
+**Priority**: Low-Medium
+**Category**: Code Quality / Test Infrastructure
+
+## Overview
+
+Standardize error handling patterns in tests to improve debugging experience and maintain consistency across the test suite.
+
+## Context
+
+During code review and application of recommendations, inconsistencies in test error handling patterns were observed:
+
+- Mix of `.unwrap()`, `.expect()`, and explicit error handling
+- Inconsistent error messages for similar failure scenarios
+- Some tests using generic error messages that don't aid debugging
+- Different patterns for handling `Result` and `Option` types in tests
+
+## Current State
+
+### Identified Patterns
+
+#### Current Mix of Error Handling:
+1. **Basic unwrap()**: `result.unwrap()` - Provides minimal context
+2. **Descriptive expect()**: `result.expect("Should succeed")` - Better context
+3. **Pattern matching**: Explicit handling with matches or if-let
+4. **Assert patterns**: Various assertion approaches for error conditions
+
+#### Examples of Inconsistency:
+- Some tests use `result.unwrap()` while others use `result.expect(...)`
+- Error messages vary in detail and helpfulness
+- Some tests check error conditions thoroughly, others superficially
+- Mixed approaches to testing error types and messages
+
+## Refactoring Goals
+
+### 1. Standardize Error Handling Patterns
+
+#### For Expected Success Cases:
+```rust
+// Preferred pattern
+let result = operation().await.expect("Operation should succeed - detailed context");
+
+// Instead of
+let result = operation().await.unwrap();
+```
+
+#### For Expected Error Cases:
+```rust
+// Preferred pattern  
+match operation().await {
+    Ok(_) => panic!("Expected operation to fail"),
+    Err(PatinoxError::Validation(e)) => {
+        assert!(e.message.contains("expected content"));
+    }
+    Err(e) => panic!("Unexpected error type: {:?}", e),
+}
+
+// Instead of mixed patterns
+```
+
+#### For Option Types:
+```rust
+// Preferred pattern
+let value = option.expect("Should have value - specific context");
+
+// Pattern matching for complex cases
+if let Some(value) = option {
+    assert_eq!(value.field, expected);
+} else {
+    panic!("Expected Some value for specific reason");
+}
+```
+
+### 2. Error Message Guidelines
+
+#### Message Content Standards:
+1. **Context**: What operation was being performed
+2. **Expectation**: What should have happened
+3. **Specificity**: Enough detail to aid debugging
+
+#### Examples:
+```rust
+// Good messages
+.expect("Tool execution should succeed with valid parameters")
+.expect("Validation should pass for safe content")
+.expect("Monitor should record events without error")
+.expect("Agent should transition to Running state")
+
+// Poor messages (avoid)
+.expect("Should work")
+.expect("Error")
+.unwrap() // No context
+```
+
+### 3. Consistent Error Testing Patterns
+
+#### Testing Specific Error Types:
+```rust
+#[tokio::test]
+async fn test_specific_error_condition() {
+    let result = operation_that_should_fail().await;
+    
+    match result {
+        Ok(_) => panic!("Expected ValidationError for unsafe content"),
+        Err(PatinoxError::Validation(validation_error)) => {
+            assert_eq!(validation_error.code, ValidationErrorCode::UnsafeContent);
+            assert!(validation_error.message.contains("blocked content"));
+        }
+        Err(e) => panic!("Expected ValidationError, got: {:?}", e),
+    }
+}
+```
+
+#### Testing Error Recovery:
+```rust
+#[tokio::test] 
+async fn test_error_recovery_behavior() {
+    // Test that systems can recover from expected error conditions
+    let result = fallible_operation().await;
+    
+    match result {
+        Ok(success) => {
+            // Verify success case
+        }
+        Err(recoverable_error) => {
+            // Verify error is recoverable and system state is consistent
+            assert!(recoverable_error.is_recoverable());
+        }
+    }
+}
+```
+
+## Implementation Plan
+
+### Phase 1: Audit Current Patterns
+- [ ] Identify all `.unwrap()` calls in test code
+- [ ] Catalog different error handling approaches
+- [ ] Document current error message patterns
+- [ ] Identify areas of inconsistency
+
+### Phase 2: Create Standard Patterns
+- [ ] Define error handling guidelines for tests
+- [ ] Create template error messages for common scenarios
+- [ ] Document preferred patterns for different error types
+- [ ] Create examples for complex error testing scenarios
+
+### Phase 3: Apply Standards Systematically
+- [ ] Replace generic `.unwrap()` calls with descriptive `.expect()`
+- [ ] Standardize error messages across similar test scenarios
+- [ ] Improve error type testing patterns
+- [ ] Add missing error condition tests where appropriate
+
+### Phase 4: Create Test Utilities
+- [ ] Create helper functions for common error testing patterns
+- [ ] Add utilities for asserting specific error types
+- [ ] Create macros for repetitive error checking patterns
+- [ ] Document test error handling best practices
+
+## Specific Areas for Improvement
+
+### 1. Result Handling
+```rust
+// Current mixed patterns - standardize to:
+let response = validator.validate(request).await
+    .expect("Validation should complete for well-formed request");
+
+// For error cases:
+let result = validator.validate(malformed_request).await;
+assert!(result.is_err(), "Should reject malformed validation request");
+```
+
+### 2. Option Handling
+```rust
+// Standardize to:
+if let Some(reason) = validation_response.reason {
+    assert!(reason.contains("expected content"));
+} else {
+    panic!("Expected validation failure to include reason");
+}
+```
+
+### 3. Complex Error Scenarios
+```rust
+// For testing error propagation:
+match complex_operation().await {
+    Err(PatinoxError::Execution(ExecutionError::AgentStateMismatch(expected, actual))) => {
+        assert_eq!(expected, "Running");
+        assert_eq!(actual, "Stopped");
+    }
+    other => panic!("Expected specific state mismatch error, got: {:?}", other),
+}
+```
+
+## Benefits
+
+- **Better Debugging**: Clear error messages aid in troubleshooting test failures
+- **Consistency**: Uniform error handling patterns across the test suite
+- **Maintainability**: Standardized approaches make tests easier to update
+- **Documentation**: Error messages serve as documentation of expected behavior
+- **Robustness**: Better error testing leads to more robust error handling
+
+## Guidelines for Implementation
+
+### Error Message Templates
+1. **Success expectations**: "{Operation} should {succeed/pass} {with/for} {context}"
+2. **Failure expectations**: "Expected {specific error type} {for/when} {condition}"
+3. **State assertions**: "{Component} should {be/have} {expected state} {after/during} {operation}"
+
+### Testing Priorities
+1. **High Priority**: Replace `.unwrap()` in critical path tests
+2. **Medium Priority**: Standardize error messages for common scenarios
+3. **Low Priority**: Add comprehensive error type testing
+
+### Safety Considerations
+- Don't change test logic, only error handling patterns
+- Maintain existing test coverage
+- Ensure error messages are helpful but not overly verbose
+- Keep performance impact minimal
+
+## Estimated Effort
+
+**Size**: Small-Medium (affects many files but changes are minor)
+**Timeline**: 2-3 hours
+**Risk**: Very Low (cosmetic changes to test infrastructure)
+
+## Dependencies
+
+- Can be done independently of other refactoring tasks
+- Should coordinate with test utility extraction to avoid conflicts
+- Benefits from completion before adding new test code
+
+## Success Criteria
+
+- [ ] No `.unwrap()` calls in test assertion paths
+- [ ] Consistent error message patterns across test modules
+- [ ] Improved error type testing coverage
+- [ ] Clear guidelines for future test error handling
+- [ ] Better debugging experience for test failures
+- [ ] Maintained test performance and coverage
+
+## Related Context
+
+- Code review recommendations application
+- Test quality assessment patterns
+- Error system design and usage patterns
+- Rust testing best practices and conventions

--- a/context-network/planning/refactoring_task_split_large_test_files.md
+++ b/context-network/planning/refactoring_task_split_large_test_files.md
@@ -1,0 +1,179 @@
+# Task: Split Large Test Files into Focused Modules
+
+**Created**: 2025-08-18 22:36 CDT
+**Status**: Planned (deferred from code review recommendations)
+**Priority**: Medium
+**Category**: Code Quality / Organization
+
+## Overview
+
+Refactor large test files (600+ lines) into smaller, focused test modules organized by functionality rather than having monolithic test modules.
+
+## Context
+
+During code review of Core Trait Interfaces implementation, several test files were identified as being too large and potentially difficult to navigate:
+
+- `src/traits/mod.rs` tests section: 656 lines total (test module portion significant)
+- `src/traits/monitor.rs` tests: 633 lines
+- `src/traits/validator.rs` tests: 457 lines 
+- `src/traits/agent.rs` tests: 438 lines
+
+Large test files make it harder to:
+- Find specific test categories
+- Understand test organization
+- Maintain and update tests
+- Review test changes effectively
+
+## Current State
+
+### File Analysis
+- **mod.rs**: Contains trait object safety tests, integration tests, mock implementations
+- **monitor.rs**: Contains serialization tests, functionality tests, object safety tests, mock implementation
+- **validator.rs**: Contains validation logic tests, serialization tests, object safety tests, mock implementation
+- **agent.rs**: Contains lifecycle tests, builder pattern tests, serialization tests, mock implementation
+
+## Refactoring Strategy
+
+### 1. Organize Tests by Category
+
+Split test modules into focused categories:
+
+#### For each trait module (agent, tool, validator, monitor):
+- `basic_functionality.rs` - Core trait method tests
+- `serialization.rs` - Serde serialization/deserialization tests  
+- `object_safety.rs` - Trait object and Send/Sync tests
+- `integration.rs` - Cross-trait integration tests
+- `error_handling.rs` - Error condition and edge case tests
+
+#### For mod.rs:
+- `trait_objects.rs` - Trait object safety verification tests
+- `integration.rs` - Cross-trait integration scenarios
+- `error_integration.rs` - Error system integration tests
+
+### 2. File Size Guidelines
+
+Target file sizes:
+- **Individual test modules**: 100-200 lines maximum
+- **Test helper modules**: 50-150 lines maximum
+- **Mock implementation modules**: 100-300 lines maximum
+
+### 3. Implementation Plan
+
+#### Phase 1: Create Module Structure
+- [ ] Create `tests/` subdirectory in each trait module
+- [ ] Create category-specific test files
+- [ ] Set up proper module declarations
+
+#### Phase 2: Extract Test Categories
+- [ ] Move serialization tests to dedicated files
+- [ ] Move object safety tests to dedicated files
+- [ ] Move basic functionality tests to dedicated files
+- [ ] Move integration tests to dedicated files
+
+#### Phase 3: Reorganize Remaining Tests
+- [ ] Group related test functions together
+- [ ] Ensure logical test flow within each file
+- [ ] Standardize test documentation and naming
+
+#### Phase 4: Update Module Structure
+- [ ] Update `mod.rs` files to include new test modules
+- [ ] Ensure all tests are still discoverable by `cargo test`
+- [ ] Verify test organization makes sense
+
+## Proposed File Structure
+
+```
+src/traits/
+├── agent/
+│   ├── mod.rs
+│   └── tests/
+│       ├── mod.rs
+│       ├── basic_functionality.rs
+│       ├── serialization.rs
+│       ├── object_safety.rs
+│       ├── builder_pattern.rs
+│       └── lifecycle.rs
+├── monitor/
+│   ├── mod.rs
+│   └── tests/
+│       ├── mod.rs
+│       ├── basic_functionality.rs
+│       ├── serialization.rs
+│       ├── object_safety.rs
+│       ├── event_handling.rs
+│       └── query_functionality.rs
+├── validator/
+│   ├── mod.rs
+│   └── tests/
+│       ├── mod.rs
+│       ├── basic_functionality.rs
+│       ├── serialization.rs
+│       ├── object_safety.rs
+│       └── validation_logic.rs
+├── tool/
+│   ├── mod.rs
+│   └── tests/
+│       ├── mod.rs
+│       ├── basic_functionality.rs
+│       ├── serialization.rs
+│       ├── object_safety.rs
+│       └── execution.rs
+└── tests/
+    ├── mod.rs
+    ├── trait_objects.rs
+    ├── integration.rs
+    └── error_integration.rs
+```
+
+## Benefits
+
+- **Improved Navigation**: Easier to find specific test categories
+- **Better Organization**: Logical grouping of related tests
+- **Easier Maintenance**: Smaller files are easier to understand and modify
+- **Clearer Intent**: File names clearly indicate test purpose
+- **Better Reviews**: Smaller, focused changes are easier to review
+- **Reduced Cognitive Load**: Developers can focus on one aspect at a time
+
+## Implementation Guidelines
+
+### Test Organization Principles
+1. **Single Responsibility**: Each test file should test one aspect/category
+2. **Clear Naming**: File names should clearly indicate what is being tested
+3. **Logical Grouping**: Related tests should be grouped together
+4. **Consistent Structure**: Similar organization across all trait modules
+
+### Migration Safety
+- Move tests incrementally to avoid breaking the build
+- Verify all tests pass after each migration step
+- Maintain test coverage throughout the process
+- Keep commit history clear about what was moved where
+
+## Estimated Effort
+
+**Size**: Medium-Large (touches all test files but is mostly organizational)
+**Timeline**: 3-4 hours
+**Risk**: Low-Medium (risk of accidentally breaking test discovery)
+
+## Dependencies
+
+- Should be done after "Extract Common Test Utilities" task
+- Requires coordination with any ongoing test development
+- Should be completed before adding new trait implementations
+
+## Success Criteria
+
+- [ ] No test file exceeds 300 lines
+- [ ] Test categories are clearly separated
+- [ ] All existing tests continue to pass
+- [ ] Test discovery (`cargo test`) finds all tests
+- [ ] Test organization is consistent across trait modules
+- [ ] Test files have clear, descriptive names
+- [ ] Related tests are logically grouped
+- [ ] Test maintainability is improved
+
+## Related Context
+
+- Code review findings from Core Trait Interfaces implementation
+- File organization best practices from Rust community
+- Test maintainability principles
+- Context network structure guidelines (atomic documents)

--- a/context-network/planning/task_add_config_validation.md
+++ b/context-network/planning/task_add_config_validation.md
@@ -1,0 +1,254 @@
+# Task: Add Configuration Validation and Bounds Checking
+
+**Created**: 2025-08-19 15:30 CDT
+**Status**: Planned (deferred from code review recommendations)
+**Priority**: Medium
+**Category**: Validation / Robustness
+
+## Overview
+
+Add bounds checking and validation for configuration values across all framework components to prevent invalid configurations and improve system robustness.
+
+## Context from Code Review
+
+**Original Recommendation**: "Missing Validation: In `validator.rs:305`, consider adding bounds checking for config priority values."
+
+**Why Deferred**: This requires systematic analysis of all configuration types and design of validation patterns. It's better to handle comprehensively rather than piecemeal.
+
+## Scope
+
+### Configuration Types to Validate:
+
+#### 1. AgentConfig (`src/traits/agent.rs`)
+- `max_concurrent_requests`: Should have reasonable bounds (1-1000)
+- `timeout_ms`: Should be positive and reasonable (1000-300000ms) 
+- `enabled_validators`: Should reference valid validators
+- `tools`: Should reference available tools
+- `llm_provider`/`llm_model`: Should be non-empty strings
+
+#### 2. ValidatorConfig (`src/traits/validator.rs`)
+- `priority`: Should have reasonable bounds (-100 to 100)
+- `stages`: Should not be empty for enabled validators
+- `parameters`: Should validate based on validator type
+
+#### 3. MonitorConfig (`src/traits/monitor.rs`)  
+- `buffer_size`: Should be positive (1-100000)
+- `flush_interval_ms`: Should be positive (100-3600000ms)
+- `sampling_rate`: Should be between 0.0 and 1.0
+- `event_types`: Should not be empty if enabled
+
+#### 4. ToolMetadata (`src/traits/tool.rs`)
+- `version`: Should follow semantic versioning pattern
+- `category`: Should be from allowed categories or non-empty
+- `tags`: Should have reasonable limits on count and length
+
+## Acceptance Criteria
+
+- [ ] All configuration types have validation methods
+- [ ] Validation provides clear, actionable error messages
+- [ ] Bounds checking prevents obviously invalid configurations
+- [ ] Validation is consistently applied during construction
+- [ ] Builder patterns include validation steps
+- [ ] Configuration deserialization includes validation
+- [ ] Performance impact of validation is minimal
+
+## Implementation Approach
+
+### Phase 1: Validation Framework Design
+- [ ] Define validation trait/pattern for configurations
+- [ ] Establish error types for validation failures
+- [ ] Design builder pattern integration
+- [ ] Plan validation timing (construction vs usage)
+
+### Phase 2: Core Configuration Validation
+- [ ] Implement AgentConfig validation
+- [ ] Implement ValidatorConfig validation  
+- [ ] Implement MonitorConfig validation
+- [ ] Implement ToolMetadata validation
+
+### Phase 3: Integration and Testing
+- [ ] Add validation to builder patterns
+- [ ] Update tests to cover validation scenarios
+- [ ] Test error messages for clarity
+- [ ] Performance test validation overhead
+
+### Phase 4: Documentation and Examples
+- [ ] Document validation rules and rationale
+- [ ] Add examples of valid and invalid configurations
+- [ ] Update builder pattern documentation
+- [ ] Add troubleshooting guide for validation errors
+
+## Validation Patterns to Implement
+
+### 1. Builder Pattern Validation
+```rust
+impl AgentBuilder {
+    pub fn max_concurrent_requests(mut self, max: u32) -> Result<Self, ConfigurationError> {
+        if max == 0 || max > 1000 {
+            return Err(ConfigurationError::InvalidValue(
+                "max_concurrent_requests must be between 1 and 1000".to_string()
+            ));
+        }
+        self.config.max_concurrent_requests = max;
+        Ok(self)
+    }
+}
+```
+
+### 2. Configuration Validation Trait
+```rust
+trait ValidateConfig {
+    type Error;
+    
+    fn validate(&self) -> Result<(), Self::Error>;
+    fn validate_field(field_name: &str, value: &dyn Any) -> Result<(), Self::Error>;
+}
+```
+
+### 3. Serde Integration
+```rust
+impl<'de> Deserialize<'de> for AgentConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let config = AgentConfigRaw::deserialize(deserializer)?;
+        config.validate().map_err(serde::de::Error::custom)?;
+        Ok(config.into())
+    }
+}
+```
+
+## Validation Rules to Implement
+
+### AgentConfig Validation:
+```rust
+fn validate_agent_config(config: &AgentConfig) -> Result<(), ConfigurationError> {
+    // Concurrent requests bounds
+    if config.max_concurrent_requests == 0 || config.max_concurrent_requests > 1000 {
+        return Err(ConfigurationError::InvalidValue(
+            "max_concurrent_requests must be between 1 and 1000".to_string()
+        ));
+    }
+    
+    // Timeout bounds (1 second to 5 minutes)
+    if config.timeout_ms < 1000 || config.timeout_ms > 300000 {
+        return Err(ConfigurationError::InvalidValue(
+            "timeout_ms must be between 1000 and 300000".to_string()
+        ));
+    }
+    
+    // Required fields
+    if config.name.trim().is_empty() {
+        return Err(ConfigurationError::MissingRequired("name".to_string()));
+    }
+    
+    if config.llm_provider.trim().is_empty() {
+        return Err(ConfigurationError::MissingRequired("llm_provider".to_string()));
+    }
+    
+    Ok(())
+}
+```
+
+### ValidatorConfig Validation:
+```rust
+fn validate_validator_config(config: &ValidatorConfig) -> Result<(), ConfigurationError> {
+    // Priority bounds
+    if config.priority < -100 || config.priority > 100 {
+        return Err(ConfigurationError::InvalidValue(
+            "priority must be between -100 and 100".to_string()
+        ));
+    }
+    
+    // Must have stages if enabled
+    if config.enabled && config.stages.is_empty() {
+        return Err(ConfigurationError::InvalidValue(
+            "enabled validator must specify at least one validation stage".to_string()
+        ));
+    }
+    
+    Ok(())
+}
+```
+
+## Error Handling Strategy
+
+### New Error Types:
+```rust
+#[derive(thiserror::Error, Debug)]
+pub enum ConfigurationValidationError {
+    #[error("Invalid value for {field}: {message}")]
+    InvalidValue { field: String, message: String },
+    
+    #[error("Value {value} for {field} is out of bounds ({min} to {max})")]
+    OutOfBounds { field: String, value: String, min: String, max: String },
+    
+    #[error("Required field {field} is missing or empty")]
+    MissingRequired { field: String },
+    
+    #[error("Invalid format for {field}: {message}")]
+    InvalidFormat { field: String, message: String },
+}
+```
+
+## Testing Strategy
+
+### Validation Test Patterns:
+```rust
+#[test]
+fn test_agent_config_validation() {
+    // Valid configuration should pass
+    let valid_config = AgentConfig { /* valid values */ };
+    assert!(valid_config.validate().is_ok());
+    
+    // Invalid concurrent requests should fail
+    let invalid_config = AgentConfig {
+        max_concurrent_requests: 0,
+        ..valid_config.clone()
+    };
+    assert!(invalid_config.validate().is_err());
+    
+    // Error message should be helpful
+    match invalid_config.validate() {
+        Err(ConfigurationValidationError::OutOfBounds { field, .. }) => {
+            assert_eq!(field, "max_concurrent_requests");
+        }
+        _ => panic!("Expected OutOfBounds error"),
+    }
+}
+```
+
+## Estimated Effort
+
+**Size**: Medium (systematic validation across multiple configuration types)
+**Timeline**: 2-3 hours  
+**Risk**: Low (validation only, improves robustness)
+
+## Dependencies
+
+- Requires stable configuration types (current PR provides this)
+- Should coordinate with builder pattern improvements
+- May need new error types in error module
+- Consider impact on existing tests
+
+## Success Metrics
+
+### Robustness Improvements:
+- Elimination of obviously invalid configurations
+- Clear error messages for configuration problems
+- Reduced runtime errors from misconfiguration
+- Improved developer experience with helpful validation
+
+### Code Quality:
+- Consistent validation patterns across all config types
+- Comprehensive test coverage for validation scenarios
+- Documentation of all validation rules and rationale
+- Performance impact is negligible
+
+## Related Context
+
+- Builds on comprehensive error system from current PR
+- Supports production readiness and operational reliability
+- Improves developer experience and reduces configuration errors
+- Enables better testing and validation of framework components

--- a/context-network/planning/task_add_integration_testing.md
+++ b/context-network/planning/task_add_integration_testing.md
@@ -1,0 +1,136 @@
+# Task: Add Integration Testing for Multi-Trait Scenarios
+
+**Created**: 2025-08-19 15:30 CDT
+**Status**: Planned (deferred from code review recommendations)
+**Priority**: High
+**Category**: Test Enhancement / Architecture
+
+## Overview
+
+Add integration tests that exercise multiple traits together to validate the complete framework behavior and trait interactions.
+
+## Context from Code Review
+
+**Original Recommendation**: "Integration Testing: Add tests exercising multiple traits together"
+
+**Why Deferred**: This requires careful design of test scenarios and potentially new test infrastructure. It's a significant effort that needs proper planning.
+
+## Scope
+
+### Integration Scenarios to Test:
+
+#### 1. Full Agent Execution Pipeline
+- Agent receives request → Validator checks content → Agent executes → Monitor records → Tool execution → Validator checks response
+
+#### 2. Error Propagation Across Traits  
+- Test that errors from one trait properly propagate through the system
+- Validate error recovery strategies work across trait boundaries
+
+#### 3. Concurrent Operations
+- Multiple agents executing simultaneously
+- Shared monitor recording events from different agents
+- Validator processing concurrent requests
+
+#### 4. Configuration Integration
+- Agent configuration affecting tool selection
+- Validator configuration filtering different content types
+- Monitor configuration affecting event collection
+
+## Acceptance Criteria
+
+- [ ] Integration test suite covering major workflow scenarios
+- [ ] Tests validate trait interactions, not just individual trait behavior
+- [ ] Error handling across trait boundaries is properly tested
+- [ ] Concurrent execution scenarios are validated
+- [ ] Configuration integration is tested
+- [ ] Tests run as part of CI pipeline
+- [ ] Clear separation between unit and integration tests
+
+## Implementation Approach
+
+### Phase 1: Test Infrastructure
+- [ ] Create integration test module structure
+- [ ] Set up shared test utilities for multi-trait scenarios
+- [ ] Design test data and configuration patterns
+- [ ] Establish test isolation patterns for concurrent scenarios
+
+### Phase 2: Core Integration Tests
+- [ ] Agent + Monitor integration (execution tracking)
+- [ ] Agent + Validator integration (content validation)  
+- [ ] Agent + Tool integration (tool execution)
+- [ ] Tool + Monitor integration (tool usage tracking)
+
+### Phase 3: Complex Scenarios
+- [ ] Full pipeline integration tests
+- [ ] Error propagation tests
+- [ ] Concurrent execution tests
+- [ ] Performance integration tests
+
+### Phase 4: CI Integration
+- [ ] Add integration tests to CI pipeline
+- [ ] Set up appropriate test timeouts
+- [ ] Configure test parallelization if needed
+
+## Test Structure Example
+
+```rust
+#[tokio::test]
+async fn test_full_agent_execution_pipeline() {
+    // Setup: Create agent, validator, monitor, tools
+    let monitor = TestMonitor::new("integration-test");
+    let validator = TestValidator::new("integration-validator");
+    let mut agent = TestAgent::new("integration-agent")
+        .with_monitor(monitor.clone())
+        .with_validator(validator.clone());
+    
+    // Execute: Full request processing
+    let request = AgentRequest { /* ... */ };
+    let response = agent.execute(request).await.expect("Execution should succeed");
+    
+    // Validate: Check that all components interacted correctly
+    assert!(validator.was_called());
+    assert!(monitor.recorded_events() > 0);
+    assert!(response.is_valid());
+}
+```
+
+## Testing Patterns to Establish
+
+### 1. Builder Pattern for Test Setup
+- Fluent configuration of multi-trait test scenarios
+- Reusable test component builders
+
+### 2. Event Verification Patterns  
+- Standardized ways to verify cross-trait interactions
+- Timeline validation for async operations
+
+### 3. Error Injection Patterns
+- Controlled failure injection to test error propagation
+- Recovery scenario validation
+
+## Estimated Effort
+
+**Size**: Large (new test infrastructure + comprehensive scenarios)
+**Timeline**: 4-6 hours
+**Risk**: Medium (new test patterns, potential CI integration complexity)
+
+## Dependencies
+
+- Requires stable core trait implementations (current PR)
+- May need mock/test infrastructure improvements
+- Should coordinate with common test utilities task
+- Consider test performance impact on CI
+
+## Related Context
+
+- Builds on comprehensive unit test foundation from current PR
+- Supports framework reliability and integration confidence
+- Enables validation of architectural decisions
+- Critical for production readiness assessment
+
+## Success Metrics
+
+- Integration test coverage for all major trait combinations
+- Clear documentation of expected interaction patterns
+- Reduced integration bugs in future development
+- Faster identification of architectural issues

--- a/context-network/planning/task_add_trait_documentation_examples.md
+++ b/context-network/planning/task_add_trait_documentation_examples.md
@@ -1,0 +1,216 @@
+# Task: Add Documentation Examples to Core Traits
+
+**Created**: 2025-08-19 15:30 CDT
+**Status**: Planned (deferred from code review recommendations)
+**Priority**: Medium  
+**Category**: Documentation / Developer Experience
+
+## Overview
+
+Add comprehensive examples to trait documentation to improve developer understanding and adoption of the Patinox framework.
+
+## Context from Code Review
+
+**Original Recommendation**: "Add more examples in trait documentation"
+
+**Why Deferred**: This requires thoughtful example design that demonstrates real-world usage patterns. It's better to create comprehensive examples after the traits are stable.
+
+## Scope
+
+### Traits Needing Documentation Examples:
+
+#### 1. Agent Trait (`src/traits/agent.rs`)
+- Basic agent implementation example
+- Lifecycle management patterns
+- Error handling in agent execution
+- Configuration and builder usage
+
+#### 2. Tool Trait (`src/traits/tool.rs`)  
+- Simple tool implementation
+- Parameter validation patterns
+- Async tool execution
+- Error reporting and metadata
+
+#### 3. Validator Trait (`src/traits/validator.rs`)
+- Content validation implementation
+- Stage-based filtering
+- Validation response patterns
+- Configuration examples
+
+#### 4. Monitor Trait (`src/traits/monitor.rs`)
+- Event collection implementation  
+- Query pattern examples
+- Configuration and sampling
+- Integration with other traits
+
+## Acceptance Criteria
+
+- [ ] Each trait has at least one complete implementation example
+- [ ] Examples demonstrate real-world usage patterns, not toy scenarios
+- [ ] Code examples are tested and guaranteed to compile
+- [ ] Examples show both happy path and error handling
+- [ ] Documentation includes usage recommendations and best practices
+- [ ] Examples are accessible to developers new to the framework
+
+## Implementation Approach
+
+### Phase 1: Example Planning
+- [ ] Identify key usage patterns for each trait
+- [ ] Design realistic but simple example scenarios
+- [ ] Plan examples that build on each other (progressive complexity)
+- [ ] Consider common developer questions and pain points
+
+### Phase 2: Core Examples
+- [ ] Write basic implementation examples for each trait
+- [ ] Include complete, compilable code samples
+- [ ] Add extensive comments explaining design decisions
+- [ ] Show proper error handling patterns
+
+### Phase 3: Advanced Examples  
+- [ ] Multi-trait integration examples
+- [ ] Configuration and customization examples
+- [ ] Performance considerations and best practices
+- [ ] Common patterns and anti-patterns
+
+### Phase 4: Testing and Validation
+- [ ] Ensure all examples compile and run
+- [ ] Add examples to documentation tests
+- [ ] Validate examples work with current API
+- [ ] Get feedback on clarity and usefulness
+
+## Example Structure Template
+
+```rust
+/// # Example: Basic File Processing Tool
+/// 
+/// This example shows how to implement a simple tool that processes
+/// files and reports usage metrics:
+/// 
+/// ```rust
+/// use patinox::prelude::*;
+/// use async_trait::async_trait;
+/// 
+/// struct FileProcessorTool {
+///     name: String,
+/// }
+/// 
+/// #[async_trait]
+/// impl Tool for FileProcessorTool {
+///     fn name(&self) -> &str {
+///         &self.name
+///     }
+///     
+///     fn description(&self) -> &str {
+///         "Processes text files and returns word count statistics"
+///     }
+///     
+///     // ... rest of implementation with detailed comments
+/// }
+/// 
+/// // Usage example
+/// #[tokio::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let tool = FileProcessorTool::new("file_processor");
+///     
+///     let params = ToolParams {
+///         call_id: "example_001".to_string(),
+///         parameters: serde_json::json!({
+///             "file_path": "/path/to/document.txt"
+///         }),
+///         context: HashMap::new(),
+///     };
+///     
+///     let result = tool.execute(params).await?;
+///     println!("Processing result: {:?}", result);
+///     
+///     Ok(())
+/// }
+/// ```
+/// 
+/// ## Key Implementation Notes
+/// 
+/// - **Parameter Validation**: Always validate input parameters and provide
+///   clear error messages for missing or invalid data
+/// - **Error Handling**: Use the framework's error types for consistent
+///   error propagation and recovery
+/// - **Resource Management**: Ensure proper cleanup of any resources
+///   acquired during tool execution
+```
+
+## Example Categories to Cover
+
+### 1. Basic Implementation Examples
+- Minimal viable implementation of each trait
+- Required methods and their purposes
+- Basic configuration and setup
+
+### 2. Error Handling Examples
+- Common error scenarios and handling
+- Error propagation between traits
+- Recovery strategies in practice
+
+### 3. Integration Examples
+- How traits work together
+- Common composition patterns
+- Framework integration points
+
+### 4. Advanced Usage Examples  
+- Performance optimization techniques
+- Custom configuration patterns
+- Extension and customization points
+
+## Testing Strategy for Examples
+
+### Documentation Tests
+```rust
+/// # Example
+/// 
+/// ```rust
+/// # use patinox::prelude::*;
+/// # async fn example() -> Result<(), PatinoxError> {
+/// let agent = AgentBuilder::new("example")
+///     .add_tool("file_processor")
+///     .build();
+/// # Ok(())
+/// # }
+/// ```
+```
+
+### Example Integration Tests
+- Separate test module that validates all documentation examples
+- Automated testing to ensure examples stay current with API changes
+- Performance tests for example implementations
+
+## Estimated Effort
+
+**Size**: Medium (comprehensive documentation across multiple traits)
+**Timeline**: 3-4 hours
+**Risk**: Low (documentation only, no functional changes)
+
+## Dependencies
+
+- Requires stable trait APIs (current PR provides this)
+- Should coordinate with integration testing task for realistic examples
+- May benefit from common test utilities for example setup
+- Consider developer feedback on current documentation gaps
+
+## Success Metrics
+
+### Documentation Quality:
+- Examples are beginner-friendly but realistic
+- Code samples compile and run successfully  
+- Examples demonstrate framework best practices
+- Documentation answers common developer questions
+
+### Developer Experience:
+- Reduced time to first successful implementation
+- Fewer support questions about basic usage
+- Increased framework adoption and satisfaction
+- Clear upgrade path from simple to advanced usage
+
+## Related Context
+
+- Builds on solid trait foundation from current PR
+- Supports framework adoption and developer onboarding
+- Complements integration testing efforts with usage examples
+- Important for open-source community engagement

--- a/context-network/planning/task_expand_error_path_testing.md
+++ b/context-network/planning/task_expand_error_path_testing.md
@@ -1,0 +1,280 @@
+# Task: Expand Error Path and Edge Case Testing
+
+**Created**: 2025-08-19 08:04 CDT
+**Status**: Planned (identified in test quality review)
+**Priority**: High
+**Category**: Test Quality / Risk Mitigation
+
+## Overview
+
+Add comprehensive error condition and edge case testing to improve robustness and catch potential runtime failures that are currently not covered by tests.
+
+## Context
+
+Test quality review identified that the current test suite focuses heavily on happy path scenarios with limited coverage of:
+- Error conditions and recovery behavior
+- Boundary conditions and edge cases  
+- Invalid input handling
+- Network/timeout scenarios
+- Resource exhaustion conditions
+
+**Immediate fixes applied**:
+- ✅ Added `agent_handles_empty_message_request` test
+- ✅ Added `validator_handles_malformed_content` test
+- ✅ Added `agent_builder_handles_edge_cases` test
+
+## Missing Error Scenarios
+
+### 1. Agent Error Handling
+**Current Gap**: Limited testing of agent failure modes
+
+**Missing Tests**:
+- Agent execution with malformed tool calls
+- Agent timeout scenarios 
+- Agent state transition failures
+- Concurrent request limit exceeded
+- Memory pressure conditions
+
+```rust
+// NEEDED: Timeout handling
+#[tokio::test]
+async fn agent_handles_llm_timeout() {
+    let mut agent = Agent::new_with_short_timeout(1000); // 1 second
+    let large_request = create_large_processing_request();
+    
+    let result = agent.execute(large_request).await;
+    match result {
+        Err(PatinoxError::Execution(ExecutionError::Timeout(_))) => {},
+        other => panic!("Expected timeout error, got: {:?}", other),
+    }
+}
+```
+
+### 2. Tool Execution Failures
+**Current Gap**: Limited error condition testing
+
+**Missing Tests**:
+- Tool execution with corrupted parameters
+- Tool dependency failures (external services down)
+- Tool resource exhaustion
+- Tool permission/authorization failures
+- Malformed JSON schema handling
+
+```rust  
+// NEEDED: Resource exhaustion
+#[tokio::test]
+async fn tool_handles_resource_exhaustion() {
+    let tool = ResourceIntensiveTool::new();
+    let excessive_params = create_memory_intensive_request();
+    
+    let result = tool.execute(excessive_params).await;
+    match result {
+        Ok(tool_result) => {
+            assert!(!tool_result.success);
+            assert!(tool_result.error.unwrap().contains("resource"));
+        },
+        Err(PatinoxError::Execution(ExecutionError::ResourceExhausted(_))) => {},
+        other => panic!("Expected resource error, got: {:?}", other),
+    }
+}
+```
+
+### 3. Validator Edge Cases
+**Current Gap**: Limited validation failure testing
+
+**Missing Tests**:
+- Validator with conflicting rules
+- Extremely large validation requests
+- Validator timeout scenarios  
+- Cyclic validation dependencies
+- Unicode/encoding edge cases
+
+```rust
+// NEEDED: Unicode edge cases
+#[tokio::test]
+async fn validator_handles_unicode_edge_cases() {
+    let validator = TestValidator::new("unicode-test");
+    
+    let unicode_request = ValidationRequest {
+        content: ValidationContent::UserMessage {
+            message: "🚀💻🔥\u{200B}\u{FEFF}".to_string(), // Mixed unicode + invisible chars
+        },
+        // ... other fields
+    };
+    
+    let result = validator.validate(unicode_request).await;
+    // Should handle gracefully without panicking
+    assert!(result.is_ok());
+}
+```
+
+### 4. Monitor Failure Scenarios  
+**Current Gap**: Limited monitoring failure testing
+
+**Missing Tests**:
+- Monitor storage corruption/unavailable
+- Monitor query with invalid parameters
+- Monitor event buffer overflow
+- Monitor with extremely high event rates
+
+```rust
+// NEEDED: Storage corruption handling  
+#[tokio::test]
+async fn monitor_handles_storage_corruption() {
+    let monitor = TestMonitor::new("corruption-test");
+    
+    // Simulate storage corruption (already partially implemented with mutex errors)
+    // Test that monitor degrades gracefully rather than panicking
+    
+    let result = monitor.record_event(create_test_event()).await;
+    match result {
+        Ok(_) => {}, // Should recover or continue
+        Err(PatinoxError::Execution(ExecutionError::ResourceExhausted(_))) => {
+            // Acceptable degradation
+        },
+        Err(e) => panic!("Should handle corruption gracefully, got: {:?}", e),
+    }
+}
+```
+
+### 5. Cross-Component Error Propagation
+**Current Gap**: Limited integration error testing  
+
+**Missing Tests**:
+- Agent → Tool → Validator error chains
+- Error context preservation across trait boundaries
+- Recovery strategy testing
+- Partial failure scenarios
+
+## Implementation Plan
+
+### Phase 1: Core Error Paths (High Priority)
+- [ ] Add timeout scenarios for all async operations
+- [ ] Add resource exhaustion testing
+- [ ] Add malformed input handling for all traits
+- [ ] Test error message quality and consistency
+
+### Phase 2: Boundary Conditions (High Priority)
+- [ ] Test with empty/null inputs
+- [ ] Test with extremely large inputs
+- [ ] Test with invalid UTF-8/Unicode
+- [ ] Test with corrupted data structures
+
+### Phase 3: Integration Error Scenarios (Medium Priority)
+- [ ] Test error propagation chains
+- [ ] Test partial failure recovery
+- [ ] Test concurrent error conditions
+- [ ] Test error context preservation
+
+### Phase 4: Performance Edge Cases (Medium Priority)
+- [ ] Test with high concurrency
+- [ ] Test with memory pressure
+- [ ] Test with slow/failing dependencies
+- [ ] Test with network partitions
+
+## Specific Test Categories to Add
+
+### Input Validation Tests
+```rust
+#[tokio::test]
+async fn trait_handles_null_bytes_in_strings() {
+    // Test with strings containing null bytes
+}
+
+#[tokio::test] 
+async fn trait_handles_extremely_large_inputs() {
+    // Test with inputs near system limits
+}
+
+#[tokio::test]
+async fn trait_handles_invalid_unicode() {
+    // Test with malformed UTF-8 sequences
+}
+```
+
+### Resource Limits Tests
+```rust
+#[tokio::test]
+async fn trait_handles_memory_exhaustion() {
+    // Test behavior when memory is constrained
+}
+
+#[tokio::test]
+async fn trait_handles_timeout_conditions() {
+    // Test timeout handling and recovery
+}
+```
+
+### Concurrency Tests
+```rust
+#[tokio::test]
+async fn trait_handles_concurrent_access() {
+    // Test thread safety under load
+}
+
+#[tokio::test]
+async fn trait_handles_race_conditions() {
+    // Test for race condition vulnerabilities
+}
+```
+
+### Error Recovery Tests
+```rust
+#[tokio::test]
+async fn trait_recovers_from_transient_failures() {
+    // Test retry and recovery logic
+}
+
+#[tokio::test]
+async fn trait_preserves_state_during_errors() {
+    // Test state consistency during failures
+}
+```
+
+## Testing Utilities Needed
+
+```rust
+// Helper functions to create edge case inputs
+fn create_large_input(size_mb: usize) -> String;
+fn create_invalid_utf8_string() -> Vec<u8>;
+fn create_timeout_scenario() -> Duration;
+fn create_memory_pressure_condition();
+```
+
+## Success Criteria
+
+- [ ] All traits have comprehensive error condition tests
+- [ ] Boundary conditions are tested for all input parameters
+- [ ] Timeout and resource exhaustion scenarios are covered
+- [ ] Error propagation chains are tested
+- [ ] Unicode/encoding edge cases are handled
+- [ ] Concurrent access error scenarios are tested
+- [ ] No panics under error conditions
+- [ ] Error messages are helpful and consistent
+
+## Estimated Effort
+
+**Size**: Large (requires comprehensive error scenario design)
+**Timeline**: 6-8 hours
+**Risk**: Low-Medium (testing error paths shouldn't break functionality)
+
+## Dependencies
+
+- Should be completed after tautological test fixes
+- May require mock enhancements for error simulation
+- Should coordinate with error system improvements
+
+## Benefits
+
+- **Improved Robustness**: Catch edge cases before they reach production
+- **Better Error Handling**: Validate error recovery mechanisms work
+- **Reduced Production Issues**: Find and fix error paths proactively
+- **Documentation**: Error tests serve as documentation of failure modes
+- **Confidence**: Better coverage of real-world scenarios
+
+## Related Context
+
+- Test quality review findings
+- Error system design and usage patterns
+- Patinox error hierarchy and recovery strategies
+- Production reliability requirements

--- a/context-network/planning/task_fix_tautological_tests.md
+++ b/context-network/planning/task_fix_tautological_tests.md
@@ -1,0 +1,185 @@
+# Task: Fix Remaining Tautological Tests
+
+**Created**: 2025-08-19 08:04 CDT  
+**Updated**: 2025-08-19 12:30 CDT
+**Status**: Partially Complete (1 true tautology fixed, review command updated)
+**Priority**: High
+**Category**: Test Quality / Bug Fix
+
+## Overview
+
+Replace remaining tautological tests that only verify mock behavior with tests that validate actual business logic and contract requirements.
+
+## Context
+
+Test quality review identified several categories of tautological tests that provide false confidence:
+- Tests that only verify constructor assignment
+- Tests that only check mock return values  
+- Tests that don't validate real business rules or constraints
+
+**Session Progress**: 
+- ✅ `agent_available_tools_list` (src/traits/mod.rs:141-155) - Fixed true tautology by testing contract requirements instead of hardcoded values
+- ✅ Updated `/review-tests` command to distinguish legitimate mock testing from true tautologies
+- ❌ Previous changes incorrectly reverted legitimate mock tests that exercise conditional logic
+
+**Important Learning**: Most identified "tautologies" were actually legitimate mock-based tests that exercise conditional logic in mocks. Only tests that verify hardcoded return values without any logic are truly tautological.
+
+## Remaining Issues
+
+### 1. Mock-Only Response Testing
+**Files**: `src/traits/mod.rs`, `src/traits/tool.rs`
+
+Several tests only verify that mocks return expected values without testing real implementation logic:
+
+```rust
+// PROBLEMATIC: Only tests mock behavior
+let result = tool.execute(params).await.expect("Should succeed");
+assert!(result.success); // Just testing mock return value
+```
+
+**Should become**:
+```rust
+// GOOD: Tests actual parameter validation
+let result = tool.execute(invalid_params).await.expect("Should complete");
+if !result.success {
+    assert!(result.error.unwrap().contains("parameter validation"));
+}
+```
+
+### 2. Serialization Round-trip Without Validation
+**Files**: `src/traits/agent.rs`, `src/traits/validator.rs`
+
+Tests that serialize then deserialize without validating the data makes sense:
+
+```rust
+// PROBLEMATIC: Only tests serde works
+let deserialized: AgentConfig = serde_json::from_str(&serialized).unwrap();
+assert_eq!(deserialized.name, config.name); // Just testing round-trip
+```
+
+**Should add**: Validation of deserialized data constraints
+
+### 3. State Transition Tests Without Logic
+**Files**: `src/traits/agent.rs`
+
+Tests that verify state changes without testing the business logic:
+
+```rust
+// NEEDS IMPROVEMENT: Should test transition constraints
+agent.start().await.expect("Should start");
+assert_eq!(agent.state(), AgentState::Running); // Just testing assignment
+```
+
+## Specific Files to Fix
+
+### `src/traits/tool.rs`
+- `tool_successful_execution` - Add parameter validation testing
+- `tool_parameter_validation` - Expand to test edge cases
+- `tool_result_with_error` - Test actual error conditions
+
+### `src/traits/agent.rs` 
+- `agent_state_*` tests - Add transition constraint validation
+- Serialization tests - Add constraint validation after deserialize
+
+### `src/traits/validator.rs`
+- `validator_service_interface` - Test actual validation logic paths
+- Config serialization - Validate deserialized constraints
+
+### `src/traits/monitor.rs`
+- Event serialization - Validate event data makes sense
+- Query tests - Test actual filtering logic
+
+## Implementation Plan
+
+### Phase 1: Parameter Validation Tests (High Priority)
+- [ ] Fix tool parameter validation to test real constraints
+- [ ] Add edge case testing for boundary conditions
+- [ ] Test error message content and types
+
+### Phase 2: Business Logic Validation (High Priority)  
+- [ ] Replace state assignment tests with transition logic tests
+- [ ] Add constraint validation to serialization tests
+- [ ] Test actual validation logic paths
+
+### Phase 3: Contract Enforcement (Medium Priority)
+- [ ] Ensure all trait methods test their contracts
+- [ ] Add negative test cases for invalid inputs
+- [ ] Validate error handling paths
+
+## Success Criteria
+
+- [ ] No tests that only verify constructor assignments
+- [ ] No tests that only check mock return values without logic
+- [ ] All tests validate actual business rules or constraints  
+- [ ] Serialization tests validate data integrity, not just round-trip
+- [ ] State transition tests validate business logic
+- [ ] All edge cases have appropriate error handling tests
+
+## Examples of Good Tests
+
+```rust
+// GOOD: Tests actual validation logic
+#[tokio::test]
+async fn validator_rejects_invalid_stage() {
+    let validator = TestValidator::new("stage-test");
+    
+    let invalid_request = ValidationRequest {
+        stage: ValidationStage::PostTool, // Not in validator's configured stages
+        // ... other fields
+    };
+    
+    assert!(!validator.should_validate(&invalid_request), 
+            "Validator should not process unconfigured stages");
+}
+
+// GOOD: Tests constraint enforcement  
+#[test]
+fn agent_config_enforces_reasonable_limits() {
+    let config = AgentConfig {
+        max_concurrent_requests: 1000, // Excessive
+        timeout_ms: 1, // Too short
+        // ... other fields
+    };
+    
+    // Should enforce reasonable constraints
+    assert!(config.max_concurrent_requests <= MAX_REASONABLE_REQUESTS);
+    assert!(config.timeout_ms >= MIN_REASONABLE_TIMEOUT);
+}
+
+// GOOD: Tests error path logic
+#[tokio::test] 
+async fn tool_handles_network_timeout() {
+    let tool = NetworkTool::new(short_timeout_config());
+    
+    let result = tool.execute(slow_network_params()).await;
+    match result {
+        Ok(tool_result) => {
+            assert!(!tool_result.success);
+            assert!(tool_result.error.unwrap().contains("timeout"));
+        },
+        Err(PatinoxError::Execution(ExecutionError::Timeout(_))) => {
+            // Also acceptable
+        },
+        other => panic!("Expected timeout handling, got: {:?}", other),
+    }
+}
+```
+
+## Estimated Effort
+
+**Size**: Medium (affects multiple test methods across files)
+**Timeline**: 3-4 hours
+**Risk**: Low (improving existing tests, not changing functionality)
+
+## Dependencies
+
+- Should be completed after common test utilities extraction
+- No external dependencies
+- Can be done incrementally per trait module
+
+## Related Context
+
+- Test quality review findings
+- Mock implementation patterns in trait modules  
+- Error handling standards established in error system
+- Business rule validation requirements

--- a/context-network/planning/task_improve_test_error_consistency.md
+++ b/context-network/planning/task_improve_test_error_consistency.md
@@ -1,0 +1,90 @@
+# Task: Improve Test Error Consistency
+
+**Created**: 2025-08-19 15:30 CDT
+**Status**: Planned (deferred from code review recommendations)
+**Priority**: Medium
+**Category**: Test Quality / Technical Debt
+
+## Overview
+
+Replace remaining `.unwrap()` calls in test code with proper error handling for consistency with the PR's safety theme.
+
+## Context from Code Review
+
+**Original Recommendation**: "Some `.unwrap()` calls remain in tests: While not critical for test code, lines like `src/traits/monitor.rs:513` could use proper error handling for consistency with the PR's safety theme."
+
+**Why Deferred**: While not critical, this is a medium-effort refactoring that affects multiple test files and should be done systematically rather than as quick fixes.
+
+## Scope
+
+### Files to Review:
+- `src/traits/mod.rs` - Test modules
+- `src/traits/monitor.rs` - Test utilities
+- `src/traits/agent.rs` - Test assertions  
+- `src/traits/validator.rs` - Test helpers
+- `src/traits/tool.rs` - Test execution
+
+### Pattern to Replace:
+```rust
+// Current pattern
+let result = some_operation().unwrap();
+
+// Preferred pattern for tests
+let result = some_operation().expect("Clear description of what should succeed");
+```
+
+## Acceptance Criteria
+
+- [ ] All `.unwrap()` calls in test code replaced with `.expect()` with descriptive messages
+- [ ] No change to test functionality or behavior
+- [ ] All tests continue to pass
+- [ ] Error messages provide clear context for debugging test failures
+- [ ] Consistent error handling patterns across all test modules
+
+## Implementation Approach
+
+### Phase 1: Audit and Catalog
+- [ ] Search for all `.unwrap()` calls in test code
+- [ ] Categorize by type (setup, assertions, cleanup)
+- [ ] Identify any that are actually appropriate (rare edge cases)
+
+### Phase 2: Systematic Replacement
+- [ ] Replace setup `.unwrap()` calls with descriptive `.expect()` messages
+- [ ] Replace assertion `.unwrap()` calls with test-specific context
+- [ ] Maintain any `.unwrap()` calls that are testing panic conditions
+
+### Phase 3: Validation
+- [ ] Run full test suite to ensure no behavior changes
+- [ ] Verify error messages are helpful for debugging
+- [ ] Check that test failure output is improved
+
+## Examples
+
+### Before:
+```rust
+let config = serde_json::from_str(&serialized).unwrap();
+```
+
+### After:
+```rust  
+let config = serde_json::from_str(&serialized)
+    .expect("Serialized config should deserialize successfully");
+```
+
+## Estimated Effort
+
+**Size**: Medium (affects multiple test files systematically)
+**Timeline**: 1-2 hours
+**Risk**: Low (test-only changes, no functional impact)
+
+## Dependencies
+
+- No external dependencies
+- Can be done incrementally per module
+- Should coordinate with any ongoing test refactoring work
+
+## Related Context
+
+- Builds on mutex error handling improvements from current PR
+- Supports overall framework safety and reliability theme
+- Aligns with professional development practices established

--- a/context-network/planning/task_improve_test_isolation.md
+++ b/context-network/planning/task_improve_test_isolation.md
@@ -1,0 +1,322 @@
+# Task: Improve Test Isolation and Independence
+
+**Created**: 2025-08-19 08:04 CDT
+**Status**: Planned (identified in test quality review)
+**Priority**: Medium
+**Category**: Test Quality / Infrastructure
+
+## Overview
+
+Fix test isolation issues to ensure tests can run independently and don't affect each other through shared state or external dependencies.
+
+## Context
+
+Test quality review identified potential isolation issues:
+- Mock implementations with shared state (mutex-wrapped collections)
+- Tests that might depend on execution order
+- Potential state leakage between test runs
+- Missing setup/teardown for stateful components
+
+## Identified Issues
+
+### 1. Shared Mock State
+**Problem**: Mock implementations use `Arc<Mutex<Vec<T>>>` for state that could leak between tests.
+
+**Location**: `src/traits/monitor.rs` and `src/traits/mod.rs`
+
+```rust
+// PROBLEMATIC: Shared state in mock
+pub struct MockMonitor {
+    events: Arc<Mutex<Vec<MonitorEvent>>>, // Could leak between tests
+}
+```
+
+**Risk**: Tests could see events from previous test runs if mocks are reused.
+
+### 2. Test Execution Order Dependencies
+**Problem**: Some tests might depend on specific execution order or state from other tests.
+
+**Current State**: Most tests appear independent, but comprehensive verification needed.
+
+### 3. External State Dependencies  
+**Problem**: Tests that rely on external state (filesystem, network, environment) could be fragile.
+
+**Current State**: Limited external dependencies identified, but should verify.
+
+### 4. Resource Cleanup
+**Problem**: Tests that create resources (threads, connections, file handles) might not clean up properly.
+
+**Current State**: Most tests are simple unit tests, but async tests need verification.
+
+## Specific Problems to Fix
+
+### Mock State Isolation
+```rust
+// CURRENT: Potentially shared state
+impl MockMonitor {
+    fn new(name: &str) -> Self {
+        Self {
+            events: Arc::new(Mutex::new(Vec::new())), // Shared reference
+        }
+    }
+}
+
+// BETTER: Guaranteed isolated state  
+impl MockMonitor {
+    fn new(name: &str) -> Self {
+        Self {
+            events: RefCell::new(Vec::new()), // Single-threaded, isolated
+        }
+    }
+}
+```
+
+### Test Setup/Teardown
+```rust
+// CURRENT: Manual setup in each test
+#[tokio::test]
+async fn some_test() {
+    let monitor = MockMonitor::new("test");
+    // test logic...
+}
+
+// BETTER: Standardized setup
+struct TestContext {
+    monitor: MockMonitor,
+    // other test fixtures
+}
+
+impl TestContext {
+    fn new() -> Self {
+        Self {
+            monitor: MockMonitor::new(&format!("test-{}", Uuid::new_v4())),
+        }
+    }
+}
+
+#[tokio::test] 
+async fn some_test() {
+    let ctx = TestContext::new();
+    // test logic with ctx.monitor...
+    // automatic cleanup when ctx drops
+}
+```
+
+### Async Resource Management
+```rust
+// CURRENT: Potential resource leaks
+#[tokio::test]
+async fn concurrent_test() {
+    let handles: Vec<_> = (0..10)
+        .map(|i| tokio::spawn(async move { /* work */ }))
+        .collect();
+    // Missing: await all handles
+}
+
+// BETTER: Proper cleanup
+#[tokio::test] 
+async fn concurrent_test() {
+    let handles: Vec<_> = (0..10)
+        .map(|i| tokio::spawn(async move { /* work */ }))
+        .collect();
+    
+    for handle in handles {
+        handle.await.expect("Task should complete");
+    }
+}
+```
+
+## Implementation Plan
+
+### Phase 1: Audit Current State
+- [ ] Identify all shared state in mock implementations
+- [ ] Review test execution patterns for dependencies
+- [ ] Check for external state dependencies
+- [ ] Verify async resource cleanup
+
+### Phase 2: Fix Mock Isolation
+- [ ] Replace shared `Arc<Mutex<>>` with isolated state
+- [ ] Ensure each test gets fresh mock instances  
+- [ ] Add unique identifiers to prevent cross-contamination
+- [ ] Verify mocks reset between tests
+
+### Phase 3: Standardize Test Setup
+- [ ] Create test context/fixture pattern
+- [ ] Implement proper setup/teardown for stateful tests
+- [ ] Add test utilities for common scenarios
+- [ ] Ensure deterministic test data
+
+### Phase 4: Verify Independence
+- [ ] Run tests in random order to detect dependencies
+- [ ] Run tests in parallel to detect race conditions
+- [ ] Add stress testing for concurrent scenarios
+- [ ] Verify no test affects others
+
+## Specific Changes Needed
+
+### `src/traits/monitor.rs` MockMonitor
+```rust
+// CHANGE: From shared state
+pub struct TestMonitor {
+    events: Arc<Mutex<Vec<MonitorEvent>>>,
+}
+
+// TO: Isolated state
+pub struct TestMonitor {
+    name: String,
+    config: MonitorConfig,
+    events: RefCell<Vec<MonitorEvent>>, // Single-threaded test isolation
+}
+
+impl TestMonitor {
+    fn new(name: &str) -> Self {
+        let unique_name = format!("{}-{}", name, Uuid::new_v4());
+        Self {
+            name: unique_name,
+            events: RefCell::new(Vec::new()),
+            // ...
+        }
+    }
+    
+    // Add cleanup method for explicit reset if needed
+    fn reset(&self) {
+        self.events.borrow_mut().clear();
+    }
+}
+```
+
+### Test Context Pattern
+```rust
+// ADD: Common test context
+struct TraitTestContext {
+    agent: MockAgent,
+    tool: MockTool,  
+    validator: MockValidator,
+    monitor: MockMonitor,
+}
+
+impl TraitTestContext {
+    fn new() -> Self {
+        let test_id = Uuid::new_v4();
+        Self {
+            agent: MockAgent::new(&format!("test-agent-{}", test_id)),
+            tool: MockTool::new(&format!("test-tool-{}", test_id)),
+            validator: MockValidator::new(&format!("test-validator-{}", test_id)),
+            monitor: MockMonitor::new(&format!("test-monitor-{}", test_id)),
+        }
+    }
+}
+
+// Usage in tests
+#[tokio::test]
+async fn isolated_test() {
+    let ctx = TraitTestContext::new();
+    // test with ctx.agent, ctx.tool, etc.
+    // automatic cleanup when ctx drops
+}
+```
+
+### Parallel Test Safety
+```rust
+// ADD: Tests for parallel execution safety
+#[tokio::test]
+async fn traits_are_parallel_safe() {
+    let num_concurrent = 10;
+    let handles: Vec<_> = (0..num_concurrent)
+        .map(|i| {
+            tokio::spawn(async move {
+                let ctx = TraitTestContext::new();
+                // Run typical test scenario
+                ctx.agent.start().await.expect("Should start");
+                // Verify no interference from other concurrent tests
+            })
+        })
+        .collect();
+        
+    for handle in handles {
+        handle.await.expect("Concurrent test should succeed");
+    }
+}
+```
+
+## Testing Isolation Verification
+
+### Random Order Testing
+```bash
+# Add to CI/testing scripts
+cargo test --shuffle-order --seed random
+```
+
+### Parallel Testing
+```bash  
+# Verify tests work in parallel
+cargo test --test-threads=$(nproc)
+```
+
+### Isolation Stress Testing
+```rust
+// ADD: Test that runs many iterations to catch rare issues
+#[tokio::test]
+async fn test_isolation_stress() {
+    for i in 0..100 {
+        let ctx = TraitTestContext::new();
+        // Run typical test operations
+        // Verify no state pollution from previous iterations
+    }
+}
+```
+
+## Success Criteria
+
+- [ ] All mock implementations use isolated state
+- [ ] Tests pass when run in random order
+- [ ] Tests pass when run in parallel
+- [ ] No shared mutable state between tests
+- [ ] Proper async resource cleanup
+- [ ] Test context pattern implemented
+- [ ] Unique identifiers prevent cross-contamination
+- [ ] Stress testing passes
+- [ ] No test dependencies detected
+
+## Risk Assessment
+
+**Low Risk Changes**:
+- Adding unique identifiers to mocks
+- Implementing test context pattern
+- Adding cleanup methods
+
+**Medium Risk Changes**:  
+- Changing mock state management (Arc<Mutex> → RefCell)
+- Modifying test execution patterns
+
+**Mitigation**:
+- Make changes incrementally
+- Run full test suite after each change
+- Keep existing test behavior identical
+
+## Estimated Effort
+
+**Size**: Medium (affects test infrastructure but changes are straightforward)
+**Timeline**: 4-5 hours
+**Risk**: Low-Medium (improving test reliability)
+
+## Dependencies
+
+- Should be done after common test utilities extraction
+- Coordinate with test file splitting task
+- May inform error path testing implementation
+
+## Benefits
+
+- **Reliable Testing**: Tests won't fail due to order or concurrency issues  
+- **Easier Debugging**: Isolated failures are easier to diagnose
+- **Parallel Execution**: Tests can run faster in parallel
+- **Maintainability**: Cleaner test setup and teardown patterns
+- **Confidence**: Tests truly validate the code, not test interactions
+
+## Related Context
+
+- Test quality review findings
+- Mock implementation patterns across trait modules
+- Async testing best practices
+- Concurrent testing patterns in Rust

--- a/context-network/planning/task_rwlock_vs_mutex_performance.md
+++ b/context-network/planning/task_rwlock_vs_mutex_performance.md
@@ -1,0 +1,160 @@
+# Task: Evaluate RwLock vs Mutex for Read-Heavy Operations
+
+**Created**: 2025-08-19 15:30 CDT
+**Status**: Planned (deferred from code review recommendations)  
+**Priority**: Medium
+**Category**: Performance Optimization / Architecture
+
+## Overview
+
+Evaluate whether `Arc<RwLock>` would provide better performance than `Arc<Mutex>` for read-heavy operations, particularly in the Monitor trait implementation.
+
+## Context from Code Review
+
+**Original Recommendation**: "Consider `Arc<RwLock>` instead of `Arc<Mutex>` for read-heavy monitor queries"
+
+**Why Deferred**: This requires performance benchmarking, API analysis, and careful consideration of concurrency patterns. It's an optimization that needs data-driven decision making.
+
+## Scope
+
+### Current Mutex Usage Analysis:
+- **Monitor trait**: Event storage and querying (`src/traits/monitor.rs`)
+- **Usage patterns**: Write events, read for queries
+- **Concurrency characteristics**: Potentially high read frequency for analytics
+
+### Areas to Evaluate:
+1. **Monitor event querying** - Primary candidate for RwLock optimization
+2. **Agent configuration access** - May benefit if frequently read
+3. **Tool metadata access** - Consider if metadata is read-heavy
+
+## Acceptance Criteria
+
+- [ ] Performance benchmark comparing Mutex vs RwLock for relevant operations
+- [ ] Analysis of read/write ratio in typical Monitor usage patterns
+- [ ] API compatibility assessment (RwLock requires different access patterns)
+- [ ] Concurrency safety analysis for existing code
+- [ ] Decision documented with performance data
+- [ ] Implementation plan if RwLock is beneficial
+
+## Implementation Approach
+
+### Phase 1: Benchmarking Infrastructure
+- [ ] Create benchmark suite for Monitor operations
+- [ ] Implement both Mutex and RwLock versions for comparison
+- [ ] Set up realistic workload scenarios (high read, mixed, high write)
+- [ ] Measure latency and throughput under different concurrency levels
+
+### Phase 2: Performance Analysis
+- [ ] Benchmark Monitor query operations with different read/write ratios
+- [ ] Test scalability with multiple concurrent readers
+- [ ] Measure impact on write operations (event recording)
+- [ ] Profile lock contention under realistic loads
+
+### Phase 3: API Impact Assessment
+- [ ] Evaluate how RwLock changes affect existing trait implementations
+- [ ] Consider ergonomics of read vs write lock acquisition
+- [ ] Assess impact on error handling patterns
+- [ ] Review compatibility with async operations
+
+### Phase 4: Decision and Implementation
+- [ ] Document findings with performance data
+- [ ] Make recommendation based on real-world usage patterns
+- [ ] If beneficial, implement RwLock with comprehensive tests
+- [ ] Update related documentation and examples
+
+## Performance Scenarios to Test
+
+### Scenario 1: Analytics-Heavy Workload
+```rust
+// High read frequency: monitoring dashboard queries
+// 90% reads (query_events), 10% writes (record_event)
+```
+
+### Scenario 2: Balanced Workload  
+```rust
+// Mixed usage: active system with regular monitoring
+// 70% reads, 30% writes
+```
+
+### Scenario 3: Write-Heavy Workload
+```rust
+// High activity system: many events being recorded
+// 30% reads, 70% writes
+```
+
+## Technical Considerations
+
+### RwLock Benefits:
+- Multiple concurrent readers
+- Better scalability for read-heavy workloads
+- Reduced lock contention for queries
+
+### RwLock Drawbacks:
+- More complex API (read() vs write() lock acquisition)
+- Potential for writer starvation
+- Overhead for simple operations
+- May not benefit write-heavy workloads
+
+### API Changes Required:
+```rust
+// Current Mutex pattern
+let events = self.events.lock().map_err(|_| error)?;
+
+// RwLock pattern for reads
+let events = self.events.read().map_err(|_| error)?;
+
+// RwLock pattern for writes  
+let mut events = self.events.write().map_err(|_| error)?;
+```
+
+## Benchmarking Framework
+
+```rust
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn benchmark_monitor_operations(c: &mut Criterion) {
+    let monitor_mutex = MonitorWithMutex::new();
+    let monitor_rwlock = MonitorWithRwLock::new();
+    
+    c.bench_function("query_events_mutex", |b| {
+        b.iter(|| monitor_mutex.query_events(query.clone()))
+    });
+    
+    c.bench_function("query_events_rwlock", |b| {
+        b.iter(|| monitor_rwlock.query_events(query.clone()))
+    });
+}
+```
+
+## Estimated Effort
+
+**Size**: Medium (benchmarking + analysis + potential implementation)
+**Timeline**: 3-4 hours
+**Risk**: Low (optimization, can revert if no benefit)
+
+## Dependencies
+
+- Requires stable Monitor trait implementation
+- Needs criterion benchmarking framework (already available)
+- Should coordinate with any Monitor usage patterns in integration tests
+- Consider real-world usage data if available
+
+## Success Metrics
+
+### Performance Improvement Thresholds:
+- **Significant benefit**: >20% improvement in read-heavy scenarios
+- **Marginal benefit**: 5-20% improvement with acceptable trade-offs
+- **No benefit**: <5% improvement or negative impact on writes
+
+### Decision Criteria:
+- Performance gains justify API complexity
+- No regression in write performance
+- Maintains or improves overall system throughput
+- Compatible with existing async patterns
+
+## Related Context
+
+- Supports overall framework performance optimization goals
+- Builds on solid foundation established in current PR
+- May inform similar decisions for other shared state components
+- Important for production scalability planning

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Local CI validation script - runs the same checks as GitHub Actions
+
+set -e  # Exit on any error
+
+echo "🔍 Running local CI validation..."
+echo
+
+echo "✅ Step 1: Check formatting"
+cargo fmt --check
+echo "✅ Formatting OK"
+echo
+
+echo "✅ Step 2: Run clippy (with warnings as errors)"
+cargo clippy --all-targets --all-features -- -D warnings
+echo "✅ Clippy OK"
+echo
+
+echo "✅ Step 3: Build project"
+cargo build
+echo "✅ Build OK"
+echo
+
+echo "✅ Step 4: Run tests"
+cargo test
+echo "✅ Tests OK"
+echo
+
+echo "✅ Step 5: Run doc tests"
+cargo test --doc
+echo "✅ Doc tests OK"
+echo
+
+echo "🎉 All local CI checks passed! Ready to push."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,12 +61,11 @@ pub mod prelude {
 
     // Re-export core trait interfaces
     pub use crate::traits::{
-        Agent, AgentState, AgentConfig, AgentRequest, AgentResponse, HealthStatus, AgentBuilder,
-        Tool, ToolCall, ToolParams, ToolResult, ToolMetadata,
-        Validator, ValidationRequest, ValidationResponse, ValidationStage, ValidationContent, 
-        ValidatorConfig, ValidationModifications,
-        Monitor, MonitorEvent, MonitorEventType, ExecutionSummary, MonitorQuery, MonitorConfig,
-        Usage,
+        Agent, AgentBuilder, AgentConfig, AgentRequest, AgentResponse, AgentState,
+        ExecutionSummary, HealthStatus, Monitor, MonitorConfig, MonitorEvent, MonitorEventType,
+        MonitorQuery, Tool, ToolCall, ToolMetadata, ToolParams, ToolResult, Usage,
+        ValidationContent, ValidationModifications, ValidationRequest, ValidationResponse,
+        ValidationStage, Validator, ValidatorConfig,
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 
 // Core modules
 pub mod error;
+pub mod traits;
 
 // Re-export core types when they become available
 pub mod prelude {
@@ -58,7 +59,15 @@ pub mod prelude {
         ValidationError,
     };
 
-    // Core types will be re-exported here as they're implemented
+    // Re-export core trait interfaces
+    pub use crate::traits::{
+        Agent, AgentState, AgentConfig, AgentRequest, AgentResponse, HealthStatus, AgentBuilder,
+        Tool, ToolCall, ToolParams, ToolResult, ToolMetadata,
+        Validator, ValidationRequest, ValidationResponse, ValidationStage, ValidationContent, 
+        ValidatorConfig, ValidationModifications,
+        Monitor, MonitorEvent, MonitorEventType, ExecutionSummary, MonitorQuery, MonitorConfig,
+        Usage,
+    };
 }
 
 // Library version and metadata

--- a/src/traits/agent.rs
+++ b/src/traits/agent.rs
@@ -52,7 +52,7 @@ mod tests {
                     crate::error::ExecutionError::AgentStateMismatch(
                         "Running".to_string(),
                         format!("{:?}", self.state),
-                    )
+                    ),
                 ));
             }
 
@@ -107,7 +107,9 @@ mod tests {
             AgentState::Started,
             AgentState::Running,
             AgentState::Stopped,
-            AgentState::Error { reason: "test".to_string() },
+            AgentState::Error {
+                reason: "test".to_string(),
+            },
         ];
 
         for state in states {
@@ -124,11 +126,17 @@ mod tests {
         let state2 = AgentState::Running;
         assert_eq!(state1, state2);
 
-        let error1 = AgentState::Error { reason: "test".to_string() };
-        let error2 = AgentState::Error { reason: "test".to_string() };
+        let error1 = AgentState::Error {
+            reason: "test".to_string(),
+        };
+        let error2 = AgentState::Error {
+            reason: "test".to_string(),
+        };
         assert_eq!(error1, error2);
 
-        let error3 = AgentState::Error { reason: "different".to_string() };
+        let error3 = AgentState::Error {
+            reason: "different".to_string(),
+        };
         assert_ne!(error1, error3);
     }
 
@@ -152,33 +160,63 @@ mod tests {
 
         // Test serialization produces valid JSON
         let serialized = serde_json::to_string(&config).expect("Should serialize");
-        assert!(!serialized.is_empty(), "Serialized output should not be empty");
-        
+        assert!(
+            !serialized.is_empty(),
+            "Serialized output should not be empty"
+        );
+
         // Verify serialized JSON contains expected structure
-        let parsed: serde_json::Value = serde_json::from_str(&serialized).expect("Should be valid JSON");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&serialized).expect("Should be valid JSON");
         assert!(parsed.is_object(), "Root should be JSON object");
         assert!(parsed.get("name").is_some(), "Should include name field");
-        assert!(parsed.get("max_concurrent_requests").is_some(), "Should include request limit");
+        assert!(
+            parsed.get("max_concurrent_requests").is_some(),
+            "Should include request limit"
+        );
 
         // Test deserialization preserves data integrity
-        let deserialized: AgentConfig = serde_json::from_str(&serialized).expect("Should deserialize");
-        
+        let deserialized: AgentConfig =
+            serde_json::from_str(&serialized).expect("Should deserialize");
+
         // Validate deserialized data meets business constraints
-        assert!(!deserialized.name.is_empty(), "Name should not be empty after deserialization");
-        assert!(deserialized.max_concurrent_requests > 0, "Request limit should be positive");
+        assert!(
+            !deserialized.name.is_empty(),
+            "Name should not be empty after deserialization"
+        );
+        assert!(
+            deserialized.max_concurrent_requests > 0,
+            "Request limit should be positive"
+        );
         assert!(deserialized.timeout_ms > 0, "Timeout should be positive");
-        assert!(!deserialized.llm_provider.is_empty(), "LLM provider should be specified");
-        assert!(!deserialized.llm_model.is_empty(), "LLM model should be specified");
-        
+        assert!(
+            !deserialized.llm_provider.is_empty(),
+            "LLM provider should be specified"
+        );
+        assert!(
+            !deserialized.llm_model.is_empty(),
+            "LLM model should be specified"
+        );
+
         // Validate collections are preserved correctly
-        assert_eq!(deserialized.enabled_validators.len(), 2, "Should preserve validator count");
-        assert!(deserialized.enabled_validators.contains(&"validator1".to_string()), "Should preserve validator names");
+        assert_eq!(
+            deserialized.enabled_validators.len(),
+            2,
+            "Should preserve validator count"
+        );
+        assert!(
+            deserialized
+                .enabled_validators
+                .contains(&"validator1".to_string()),
+            "Should preserve validator names"
+        );
         assert_eq!(deserialized.tools.len(), 2, "Should preserve tool count");
         assert_eq!(deserialized.metadata.len(), 1, "Should preserve metadata");
-        
+
         // Test serialization is deterministic for same data
         let reserialized = serde_json::to_string(&deserialized).expect("Should reserialize");
-        let reparsed: serde_json::Value = serde_json::from_str(&reserialized).expect("Should be valid JSON");
+        let reparsed: serde_json::Value =
+            serde_json::from_str(&reserialized).expect("Should be valid JSON");
         assert_eq!(parsed, reparsed, "Serialization should be deterministic");
     }
 
@@ -198,45 +236,85 @@ mod tests {
 
         // Test builder creates valid, well-formed configuration
         assert!(!config.name.is_empty(), "Agent name should not be empty");
-        assert!(config.description.is_some(), "Builder should set description");
-        assert!(config.max_concurrent_requests > 0, "Should allow concurrent requests");
+        assert!(
+            config.description.is_some(),
+            "Builder should set description"
+        );
+        assert!(
+            config.max_concurrent_requests > 0,
+            "Should allow concurrent requests"
+        );
         assert!(config.timeout_ms >= 1000, "Timeout should be reasonable");
-        
+
         // Test collection management works correctly
-        assert!(config.enabled_validators.len() >= 2, "Should accumulate validators");
-        assert!(config.enabled_validators.contains(&"anti-jailbreak".to_string()), 
-                "Should preserve validator order/content");
+        assert!(
+            config.enabled_validators.len() >= 2,
+            "Should accumulate validators"
+        );
+        assert!(
+            config
+                .enabled_validators
+                .contains(&"anti-jailbreak".to_string()),
+            "Should preserve validator order/content"
+        );
         assert!(config.tools.len() >= 2, "Should accumulate tools");
-        assert!(config.tools.contains(&"search".to_string()), 
-                "Should preserve tool content");
-        
+        assert!(
+            config.tools.contains(&"search".to_string()),
+            "Should preserve tool content"
+        );
+
         // Test required fields are set
-        assert!(!config.llm_provider.is_empty(), "LLM provider should be specified");
-        assert!(!config.llm_model.is_empty(), "LLM model should be specified");
+        assert!(
+            !config.llm_provider.is_empty(),
+            "LLM provider should be specified"
+        );
+        assert!(
+            !config.llm_model.is_empty(),
+            "LLM model should be specified"
+        );
     }
 
     #[test]
     fn agent_builder_handles_edge_cases() {
         // Test builder with minimal configuration
-        let minimal_config = AgentBuilder::new("")
-            .build();
-            
+        let minimal_config = AgentBuilder::new("").build();
+
         // Builder should apply sensible defaults for edge cases
-        assert!(minimal_config.max_concurrent_requests > 0, "Should default to positive concurrency");
-        assert!(minimal_config.timeout_ms > 0, "Should default to positive timeout");
-        assert!(!minimal_config.llm_provider.is_empty(), "Should have default LLM provider");
-        assert!(!minimal_config.llm_model.is_empty(), "Should have default LLM model");
-        
+        assert!(
+            minimal_config.max_concurrent_requests > 0,
+            "Should default to positive concurrency"
+        );
+        assert!(
+            minimal_config.timeout_ms > 0,
+            "Should default to positive timeout"
+        );
+        assert!(
+            !minimal_config.llm_provider.is_empty(),
+            "Should have default LLM provider"
+        );
+        assert!(
+            !minimal_config.llm_model.is_empty(),
+            "Should have default LLM model"
+        );
+
         // Test builder accumulates items correctly
         let multi_tool_config = AgentBuilder::new("multi-tool")
             .add_tool("tool1")
             .add_tool("tool2")
             .add_tool("tool1") // Duplicate
             .build();
-            
-        assert_eq!(multi_tool_config.tools.len(), 3, "Should preserve all tool additions");
+
         assert_eq!(
-            multi_tool_config.tools.iter().filter(|&t| t == "tool1").count(),
+            multi_tool_config.tools.len(),
+            3,
+            "Should preserve all tool additions"
+        );
+        assert_eq!(
+            multi_tool_config
+                .tools
+                .iter()
+                .filter(|&t| t == "tool1")
+                .count(),
             2,
             "Should allow duplicate tools"
         );
@@ -258,7 +336,8 @@ mod tests {
         };
 
         let serialized = serde_json::to_string(&request).expect("Should serialize request");
-        let _deserialized: AgentRequest = serde_json::from_str(&serialized).expect("Should deserialize request");
+        let _deserialized: AgentRequest =
+            serde_json::from_str(&serialized).expect("Should deserialize request");
 
         let response = AgentResponse {
             request_id: request.id,
@@ -274,14 +353,19 @@ mod tests {
         };
 
         let serialized = serde_json::to_string(&response).expect("Should serialize response");
-        let _deserialized: AgentResponse = serde_json::from_str(&serialized).expect("Should deserialize response");
+        let _deserialized: AgentResponse =
+            serde_json::from_str(&serialized).expect("Should deserialize response");
     }
 
     #[test]
     fn health_status_variants() {
         let healthy = HealthStatus::Healthy;
-        let degraded = HealthStatus::Degraded { reason: "High latency".to_string() };
-        let unhealthy = HealthStatus::Unhealthy { reason: "Connection failed".to_string() };
+        let degraded = HealthStatus::Degraded {
+            reason: "High latency".to_string(),
+        };
+        let unhealthy = HealthStatus::Unhealthy {
+            reason: "Connection failed".to_string(),
+        };
 
         // Should be able to debug print all variants
         assert!(!format!("{:?}", healthy).is_empty());
@@ -298,7 +382,7 @@ mod tests {
     async fn test_agent_object_safety() {
         // Test that we can create trait objects
         let agent: Box<dyn Agent> = Box::new(TestAgent::new("test"));
-        
+
         // Test that trait object methods work
         let _id = agent.id();
         let _state = agent.state();
@@ -330,12 +414,14 @@ mod tests {
         tokio::spawn(async move {
             let _id = agent.id();
             // Agent trait object can be moved across threads
-        }).await.unwrap();
+        })
+        .await
+        .unwrap();
     }
 }
 
 /// Core agent abstraction with minimal typestate pattern
-/// 
+///
 /// This trait defines the minimum interface contract while allowing
 /// implementations to be as sophisticated as needed. The state enum
 /// covers essential states that all agents need, but implementations
@@ -344,37 +430,37 @@ mod tests {
 pub trait Agent: Send + Sync {
     /// Agent identifier
     fn id(&self) -> Uuid;
-    
+
     /// Current agent state (simplified for compatibility)
-    /// 
+    ///
     /// Implementations with detailed internal states should map
     /// their internal state to one of these core states.
     fn state(&self) -> AgentState;
-    
+
     /// Agent configuration
     fn config(&self) -> &AgentConfig;
-    
+
     /// Start the agent (Created -> Started/Running)
     async fn start(&mut self) -> Result<(), PatinoxError>;
-    
+
     /// Stop the agent (any state -> Stopped)
     async fn stop(&mut self) -> Result<(), PatinoxError>;
-    
+
     /// Execute a request through the agent pipeline
     async fn execute(&mut self, request: AgentRequest) -> Result<AgentResponse, PatinoxError>;
-    
+
     /// Get available tools for this agent
     fn available_tools(&self) -> Vec<String>;
-    
+
     /// Health check for monitoring
-    /// 
+    ///
     /// Implementations can include detailed state information
     /// in the metadata for debugging and monitoring.
     async fn health(&self) -> HealthStatus;
 }
 
 /// Core agent states - minimal but extensible
-/// 
+///
 /// These five states cover the essential lifecycle that all agents share.
 /// Implementations can have richer internal state machines that map to these.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -451,42 +537,42 @@ impl AgentBuilder {
             },
         }
     }
-    
+
     pub fn description(mut self, desc: impl Into<String>) -> Self {
         self.config.description = Some(desc.into());
         self
     }
-    
+
     pub fn max_concurrent_requests(mut self, max: u32) -> Self {
         self.config.max_concurrent_requests = max;
         self
     }
-    
+
     pub fn timeout_ms(mut self, timeout: u64) -> Self {
         self.config.timeout_ms = timeout;
         self
     }
-    
+
     pub fn add_validator(mut self, validator: impl Into<String>) -> Self {
         self.config.enabled_validators.push(validator.into());
         self
     }
-    
+
     pub fn add_tool(mut self, tool: impl Into<String>) -> Self {
         self.config.tools.push(tool.into());
         self
     }
-    
+
     pub fn llm_provider(mut self, provider: impl Into<String>) -> Self {
         self.config.llm_provider = provider.into();
         self
     }
-    
+
     pub fn llm_model(mut self, model: impl Into<String>) -> Self {
         self.config.llm_model = model.into();
         self
     }
-    
+
     pub fn build(self) -> AgentConfig {
         self.config
     }

--- a/src/traits/agent.rs
+++ b/src/traits/agent.rs
@@ -1,0 +1,493 @@
+//! Agent trait definition and supporting types
+//!
+//! This module defines the core Agent trait that all agent implementations
+//! must implement. The trait is designed to be object-safe and supports
+//! async execution with proper error handling.
+
+use crate::error::PatinoxError;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+// Tests are written FIRST to define the contract
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Mock implementation for testing (minimal, just to make tests compile)
+    struct TestAgent {
+        id: Uuid,
+        state: AgentState,
+        config: AgentConfig,
+    }
+
+    #[async_trait]
+    impl Agent for TestAgent {
+        fn id(&self) -> Uuid {
+            self.id
+        }
+
+        fn state(&self) -> AgentState {
+            self.state.clone()
+        }
+
+        fn config(&self) -> &AgentConfig {
+            &self.config
+        }
+
+        async fn start(&mut self) -> Result<(), PatinoxError> {
+            self.state = AgentState::Running;
+            Ok(())
+        }
+
+        async fn stop(&mut self) -> Result<(), PatinoxError> {
+            self.state = AgentState::Stopped;
+            Ok(())
+        }
+
+        async fn execute(&mut self, request: AgentRequest) -> Result<AgentResponse, PatinoxError> {
+            if !matches!(self.state, AgentState::Running) {
+                return Err(PatinoxError::Execution(
+                    crate::error::ExecutionError::AgentStateMismatch(
+                        "Running".to_string(),
+                        format!("{:?}", self.state),
+                    )
+                ));
+            }
+
+            Ok(AgentResponse {
+                request_id: request.id,
+                message: format!("Processed: {}", request.message),
+                tool_results: vec![],
+                usage: crate::traits::Usage {
+                    prompt_tokens: 10,
+                    completion_tokens: 20,
+                    total_tokens: 30,
+                    cost_usd: Some(0.001),
+                },
+                metadata: HashMap::new(),
+            })
+        }
+
+        fn available_tools(&self) -> Vec<String> {
+            vec!["mock-tool".to_string()]
+        }
+
+        async fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+    }
+
+    impl TestAgent {
+        fn new(name: &str) -> Self {
+            Self {
+                id: Uuid::new_v4(),
+                state: AgentState::Created,
+                config: AgentConfig {
+                    name: name.to_string(),
+                    description: Some("Test agent".to_string()),
+                    max_concurrent_requests: 5,
+                    timeout_ms: 30000,
+                    enabled_validators: vec!["test-validator".to_string()],
+                    llm_provider: "test".to_string(),
+                    llm_model: "test-model".to_string(),
+                    tools: vec!["mock-tool".to_string()],
+                    metadata: HashMap::new(),
+                },
+            }
+        }
+    }
+
+    #[test]
+    fn agent_state_enum_completeness() {
+        // Test all variants exist and are accessible
+        let states = vec![
+            AgentState::Created,
+            AgentState::Started,
+            AgentState::Running,
+            AgentState::Stopped,
+            AgentState::Error { reason: "test".to_string() },
+        ];
+
+        for state in states {
+            // Should be able to debug print
+            let _debug = format!("{:?}", state);
+            // Should be able to clone
+            let _cloned = state.clone();
+        }
+    }
+
+    #[test]
+    fn agent_state_equality() {
+        let state1 = AgentState::Running;
+        let state2 = AgentState::Running;
+        assert_eq!(state1, state2);
+
+        let error1 = AgentState::Error { reason: "test".to_string() };
+        let error2 = AgentState::Error { reason: "test".to_string() };
+        assert_eq!(error1, error2);
+
+        let error3 = AgentState::Error { reason: "different".to_string() };
+        assert_ne!(error1, error3);
+    }
+
+    #[test]
+    fn agent_config_serialization() {
+        let config = AgentConfig {
+            name: "test-agent".to_string(),
+            description: Some("Test description".to_string()),
+            max_concurrent_requests: 10,
+            timeout_ms: 5000,
+            enabled_validators: vec!["validator1".to_string(), "validator2".to_string()],
+            llm_provider: "openai".to_string(),
+            llm_model: "gpt-4".to_string(),
+            tools: vec!["tool1".to_string(), "tool2".to_string()],
+            metadata: {
+                let mut map = HashMap::new();
+                map.insert("key1".to_string(), "value1".to_string());
+                map
+            },
+        };
+
+        // Test serialization produces valid JSON
+        let serialized = serde_json::to_string(&config).expect("Should serialize");
+        assert!(!serialized.is_empty(), "Serialized output should not be empty");
+        
+        // Verify serialized JSON contains expected structure
+        let parsed: serde_json::Value = serde_json::from_str(&serialized).expect("Should be valid JSON");
+        assert!(parsed.is_object(), "Root should be JSON object");
+        assert!(parsed.get("name").is_some(), "Should include name field");
+        assert!(parsed.get("max_concurrent_requests").is_some(), "Should include request limit");
+
+        // Test deserialization preserves data integrity
+        let deserialized: AgentConfig = serde_json::from_str(&serialized).expect("Should deserialize");
+        
+        // Validate deserialized data meets business constraints
+        assert!(!deserialized.name.is_empty(), "Name should not be empty after deserialization");
+        assert!(deserialized.max_concurrent_requests > 0, "Request limit should be positive");
+        assert!(deserialized.timeout_ms > 0, "Timeout should be positive");
+        assert!(!deserialized.llm_provider.is_empty(), "LLM provider should be specified");
+        assert!(!deserialized.llm_model.is_empty(), "LLM model should be specified");
+        
+        // Validate collections are preserved correctly
+        assert_eq!(deserialized.enabled_validators.len(), 2, "Should preserve validator count");
+        assert!(deserialized.enabled_validators.contains(&"validator1".to_string()), "Should preserve validator names");
+        assert_eq!(deserialized.tools.len(), 2, "Should preserve tool count");
+        assert_eq!(deserialized.metadata.len(), 1, "Should preserve metadata");
+        
+        // Test serialization is deterministic for same data
+        let reserialized = serde_json::to_string(&deserialized).expect("Should reserialize");
+        let reparsed: serde_json::Value = serde_json::from_str(&reserialized).expect("Should be valid JSON");
+        assert_eq!(parsed, reparsed, "Serialization should be deterministic");
+    }
+
+    #[test]
+    fn agent_builder_pattern() {
+        let config = AgentBuilder::new("test-agent")
+            .description("Test agent description")
+            .max_concurrent_requests(15)
+            .timeout_ms(60000)
+            .add_validator("anti-jailbreak")
+            .add_validator("rate-limit")
+            .add_tool("search")
+            .add_tool("calculator")
+            .llm_provider("openai")
+            .llm_model("gpt-4")
+            .build();
+
+        // Test builder creates valid, well-formed configuration
+        assert!(!config.name.is_empty(), "Agent name should not be empty");
+        assert!(config.description.is_some(), "Builder should set description");
+        assert!(config.max_concurrent_requests > 0, "Should allow concurrent requests");
+        assert!(config.timeout_ms >= 1000, "Timeout should be reasonable");
+        
+        // Test collection management works correctly
+        assert!(config.enabled_validators.len() >= 2, "Should accumulate validators");
+        assert!(config.enabled_validators.contains(&"anti-jailbreak".to_string()), 
+                "Should preserve validator order/content");
+        assert!(config.tools.len() >= 2, "Should accumulate tools");
+        assert!(config.tools.contains(&"search".to_string()), 
+                "Should preserve tool content");
+        
+        // Test required fields are set
+        assert!(!config.llm_provider.is_empty(), "LLM provider should be specified");
+        assert!(!config.llm_model.is_empty(), "LLM model should be specified");
+    }
+
+    #[test]
+    fn agent_builder_handles_edge_cases() {
+        // Test builder with minimal configuration
+        let minimal_config = AgentBuilder::new("")
+            .build();
+            
+        // Builder should apply sensible defaults for edge cases
+        assert!(minimal_config.max_concurrent_requests > 0, "Should default to positive concurrency");
+        assert!(minimal_config.timeout_ms > 0, "Should default to positive timeout");
+        assert!(!minimal_config.llm_provider.is_empty(), "Should have default LLM provider");
+        assert!(!minimal_config.llm_model.is_empty(), "Should have default LLM model");
+        
+        // Test builder accumulates items correctly
+        let multi_tool_config = AgentBuilder::new("multi-tool")
+            .add_tool("tool1")
+            .add_tool("tool2")
+            .add_tool("tool1") // Duplicate
+            .build();
+            
+        assert_eq!(multi_tool_config.tools.len(), 3, "Should preserve all tool additions");
+        assert_eq!(
+            multi_tool_config.tools.iter().filter(|&t| t == "tool1").count(),
+            2,
+            "Should allow duplicate tools"
+        );
+    }
+
+    #[test]
+    fn agent_request_response_serialization() {
+        let request = AgentRequest {
+            id: Uuid::new_v4(),
+            user_id: Some("user123".to_string()),
+            message: "Hello world".to_string(),
+            tool_calls: vec![],
+            context: {
+                let mut ctx = HashMap::new();
+                ctx.insert("session".to_string(), serde_json::json!("session123"));
+                ctx
+            },
+            metadata: HashMap::new(),
+        };
+
+        let serialized = serde_json::to_string(&request).expect("Should serialize request");
+        let _deserialized: AgentRequest = serde_json::from_str(&serialized).expect("Should deserialize request");
+
+        let response = AgentResponse {
+            request_id: request.id,
+            message: "Hello back".to_string(),
+            tool_results: vec![],
+            usage: crate::traits::Usage {
+                prompt_tokens: 10,
+                completion_tokens: 5,
+                total_tokens: 15,
+                cost_usd: Some(0.001),
+            },
+            metadata: HashMap::new(),
+        };
+
+        let serialized = serde_json::to_string(&response).expect("Should serialize response");
+        let _deserialized: AgentResponse = serde_json::from_str(&serialized).expect("Should deserialize response");
+    }
+
+    #[test]
+    fn health_status_variants() {
+        let healthy = HealthStatus::Healthy;
+        let degraded = HealthStatus::Degraded { reason: "High latency".to_string() };
+        let unhealthy = HealthStatus::Unhealthy { reason: "Connection failed".to_string() };
+
+        // Should be able to debug print all variants
+        assert!(!format!("{:?}", healthy).is_empty());
+        assert!(!format!("{:?}", degraded).is_empty());
+        assert!(!format!("{:?}", unhealthy).is_empty());
+
+        // Should be cloneable
+        let _healthy_clone = healthy.clone();
+        let _degraded_clone = degraded.clone();
+        let _unhealthy_clone = unhealthy.clone();
+    }
+
+    #[tokio::test]
+    async fn test_agent_object_safety() {
+        // Test that we can create trait objects
+        let agent: Box<dyn Agent> = Box::new(TestAgent::new("test"));
+        
+        // Test that trait object methods work
+        let _id = agent.id();
+        let _state = agent.state();
+        let _config = agent.config();
+        let _tools = agent.available_tools();
+        let _health = agent.health().await;
+
+        // Test that we can store multiple agents in a collection
+        let agents: Vec<Box<dyn Agent>> = vec![
+            Box::new(TestAgent::new("agent1")),
+            Box::new(TestAgent::new("agent2")),
+        ];
+
+        assert_eq!(agents.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_agent_send_sync() {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+
+        assert_send::<Box<dyn Agent>>();
+        assert_sync::<Box<dyn Agent>>();
+
+        // Test that we can pass trait objects across thread boundaries
+        let agent: Box<dyn Agent> = Box::new(TestAgent::new("test"));
+        let _agent_id = agent.id();
+
+        tokio::spawn(async move {
+            let _id = agent.id();
+            // Agent trait object can be moved across threads
+        }).await.unwrap();
+    }
+}
+
+/// Core agent abstraction with minimal typestate pattern
+/// 
+/// This trait defines the minimum interface contract while allowing
+/// implementations to be as sophisticated as needed. The state enum
+/// covers essential states that all agents need, but implementations
+/// can augment with detailed internal states as needed.
+#[async_trait]
+pub trait Agent: Send + Sync {
+    /// Agent identifier
+    fn id(&self) -> Uuid;
+    
+    /// Current agent state (simplified for compatibility)
+    /// 
+    /// Implementations with detailed internal states should map
+    /// their internal state to one of these core states.
+    fn state(&self) -> AgentState;
+    
+    /// Agent configuration
+    fn config(&self) -> &AgentConfig;
+    
+    /// Start the agent (Created -> Started/Running)
+    async fn start(&mut self) -> Result<(), PatinoxError>;
+    
+    /// Stop the agent (any state -> Stopped)
+    async fn stop(&mut self) -> Result<(), PatinoxError>;
+    
+    /// Execute a request through the agent pipeline
+    async fn execute(&mut self, request: AgentRequest) -> Result<AgentResponse, PatinoxError>;
+    
+    /// Get available tools for this agent
+    fn available_tools(&self) -> Vec<String>;
+    
+    /// Health check for monitoring
+    /// 
+    /// Implementations can include detailed state information
+    /// in the metadata for debugging and monitoring.
+    async fn health(&self) -> HealthStatus;
+}
+
+/// Core agent states - minimal but extensible
+/// 
+/// These five states cover the essential lifecycle that all agents share.
+/// Implementations can have richer internal state machines that map to these.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentState {
+    /// Agent exists but hasn't been started
+    Created,
+    /// Agent is starting up (loading config, connecting to services)
+    Started,
+    /// Agent is actively processing requests
+    Running,
+    /// Agent has been stopped and cannot process requests
+    Stopped,
+    /// Agent encountered an error and may need intervention
+    Error { reason: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentConfig {
+    pub name: String,
+    pub description: Option<String>,
+    pub max_concurrent_requests: u32,
+    pub timeout_ms: u64,
+    pub enabled_validators: Vec<String>,
+    pub llm_provider: String,
+    pub llm_model: String,
+    pub tools: Vec<String>,
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentRequest {
+    pub id: Uuid,
+    pub user_id: Option<String>,
+    pub message: String,
+    pub tool_calls: Vec<crate::traits::tool::ToolCall>,
+    pub context: HashMap<String, serde_json::Value>,
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentResponse {
+    pub request_id: Uuid,
+    pub message: String,
+    pub tool_results: Vec<crate::traits::tool::ToolResult>,
+    pub usage: crate::traits::Usage,
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum HealthStatus {
+    Healthy,
+    Degraded { reason: String },
+    Unhealthy { reason: String },
+}
+
+/// Builder pattern for agent configuration
+pub struct AgentBuilder {
+    config: AgentConfig,
+}
+
+impl AgentBuilder {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            config: AgentConfig {
+                name: name.into(),
+                description: None,
+                max_concurrent_requests: 10,
+                timeout_ms: 30000,
+                enabled_validators: vec![],
+                llm_provider: "openai".to_string(),
+                llm_model: "gpt-4".to_string(),
+                tools: vec![],
+                metadata: HashMap::new(),
+            },
+        }
+    }
+    
+    pub fn description(mut self, desc: impl Into<String>) -> Self {
+        self.config.description = Some(desc.into());
+        self
+    }
+    
+    pub fn max_concurrent_requests(mut self, max: u32) -> Self {
+        self.config.max_concurrent_requests = max;
+        self
+    }
+    
+    pub fn timeout_ms(mut self, timeout: u64) -> Self {
+        self.config.timeout_ms = timeout;
+        self
+    }
+    
+    pub fn add_validator(mut self, validator: impl Into<String>) -> Self {
+        self.config.enabled_validators.push(validator.into());
+        self
+    }
+    
+    pub fn add_tool(mut self, tool: impl Into<String>) -> Self {
+        self.config.tools.push(tool.into());
+        self
+    }
+    
+    pub fn llm_provider(mut self, provider: impl Into<String>) -> Self {
+        self.config.llm_provider = provider.into();
+        self
+    }
+    
+    pub fn llm_model(mut self, model: impl Into<String>) -> Self {
+        self.config.llm_model = model.into();
+        self
+    }
+    
+    pub fn build(self) -> AgentConfig {
+        self.config
+    }
+}

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -247,7 +247,7 @@ mod tests {
         let metadata = tool.metadata();
         assert!(!metadata.category.is_empty(), "Tool should have a category");
         assert!(!metadata.version.is_empty(), "Tool should have a version");
-        assert!(metadata.tags.len() > 0, "Tool should have at least one tag");
+        assert!(!metadata.tags.is_empty(), "Tool should have at least one tag");
     }
 
     #[tokio::test]

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -17,12 +17,12 @@ mod tests {
     fn agent_trait_is_object_safe() {
         // This test will compile if Agent trait is object-safe
         // We create a vector of trait objects to verify object safety
-        
+
         #[allow(dead_code)]
         fn accepts_agent_trait_object(_agent: Box<dyn Agent>) {
             // Function that accepts a trait object
         }
-        
+
         // If this compiles, the trait is object-safe
         // We'll implement MockAgent to make this pass
     }
@@ -33,7 +33,7 @@ mod tests {
         fn accepts_tool_trait_object(_tool: Box<dyn Tool>) {
             // Function that accepts a trait object
         }
-        
+
         // Vector of trait objects to verify object safety
         let _tools: Vec<Box<dyn Tool>> = Vec::new();
     }
@@ -44,7 +44,7 @@ mod tests {
         fn accepts_validator_trait_object(_validator: Box<dyn Validator>) {
             // Function that accepts a trait object
         }
-        
+
         // Vector of trait objects to verify object safety
         let _validators: Vec<Box<dyn Validator>> = Vec::new();
     }
@@ -55,7 +55,7 @@ mod tests {
         fn accepts_monitor_trait_object(_monitor: Box<dyn Monitor>) {
             // Function that accepts a trait object
         }
-        
+
         // Vector of trait objects to verify object safety
         let _monitors: Vec<Box<dyn Monitor>> = Vec::new();
     }
@@ -65,10 +65,10 @@ mod tests {
     #[tokio::test]
     async fn agent_lifecycle_state_transitions() {
         let mut agent = MockAgent::new("test-agent");
-        
+
         // Initial state should be Created and agent should not be executable
         assert_eq!(agent.state(), AgentState::Created);
-        
+
         // Test that agent cannot execute in Created state
         let test_request = AgentRequest {
             id: Uuid::new_v4(),
@@ -78,30 +78,45 @@ mod tests {
             context: HashMap::new(),
             metadata: HashMap::new(),
         };
-        
+
         let initial_result = agent.execute(test_request.clone()).await;
-        assert!(initial_result.is_err(), "Agent should not execute in Created state");
-        
+        assert!(
+            initial_result.is_err(),
+            "Agent should not execute in Created state"
+        );
+
         // Start the agent and verify it becomes executable
-        agent.start().await.expect("Agent should start successfully");
+        agent
+            .start()
+            .await
+            .expect("Agent should start successfully");
         assert_eq!(agent.state(), AgentState::Running);
-        
+
         // Test that agent can execute in Running state
         let running_result = agent.execute(test_request.clone()).await;
-        assert!(running_result.is_ok(), "Agent should execute in Running state");
-        
+        assert!(
+            running_result.is_ok(),
+            "Agent should execute in Running state"
+        );
+
         // Stop the agent and verify it becomes non-executable again
         agent.stop().await.expect("Agent should stop successfully");
         assert_eq!(agent.state(), AgentState::Stopped);
-        
+
         // Test that agent cannot execute in Stopped state
         let stopped_result = agent.execute(test_request).await;
-        assert!(stopped_result.is_err(), "Agent should not execute in Stopped state");
-        
+        assert!(
+            stopped_result.is_err(),
+            "Agent should not execute in Stopped state"
+        );
+
         // Test multiple start/stop cycles work correctly
-        agent.start().await.expect("Agent should restart from Stopped");
+        agent
+            .start()
+            .await
+            .expect("Agent should restart from Stopped");
         assert_eq!(agent.state(), AgentState::Running);
-        
+
         agent.stop().await.expect("Agent should stop again");
         assert_eq!(agent.state(), AgentState::Stopped);
     }
@@ -110,14 +125,14 @@ mod tests {
     async fn agent_has_unique_id() {
         let agent1 = MockAgent::new("agent1");
         let agent2 = MockAgent::new("agent2");
-        
+
         assert_ne!(agent1.id(), agent2.id(), "Each agent should have unique ID");
     }
 
     #[tokio::test]
     async fn agent_execute_requires_running_state() {
         let mut agent = MockAgent::new("test-agent");
-        
+
         let request = AgentRequest {
             id: Uuid::new_v4(),
             user_id: Some("user123".to_string()),
@@ -126,28 +141,37 @@ mod tests {
             context: HashMap::new(),
             metadata: HashMap::new(),
         };
-        
+
         // Should fail when not started
         let result = agent.execute(request.clone()).await;
-        assert!(result.is_err(), "Execute should fail when agent not started");
-        
+        assert!(
+            result.is_err(),
+            "Execute should fail when agent not started"
+        );
+
         // Should succeed when started
         agent.start().await.expect("Agent should start");
         let result = agent.execute(request).await;
-        assert!(result.is_ok(), "Execute should succeed when agent is running");
+        assert!(
+            result.is_ok(),
+            "Execute should succeed when agent is running"
+        );
     }
 
     #[tokio::test]
     async fn agent_available_tools_list() {
         let agent = MockAgent::new("test-agent");
         let tools = agent.available_tools();
-        
+
         // Test that agent provides tools list (contract requirement)
         assert!(!tools.is_empty(), "Agent should have available tools");
         // Test that all tool names are valid (non-empty strings)
         for tool in &tools {
             assert!(!tool.is_empty(), "Tool names should not be empty");
-            assert!(!tool.chars().all(|c| c.is_whitespace()), "Tool names should not be only whitespace");
+            assert!(
+                !tool.chars().all(|c| c.is_whitespace()),
+                "Tool names should not be only whitespace"
+            );
         }
         // Test that tools list is deterministic (same agent returns same tools)
         let tools2 = agent.available_tools();
@@ -158,7 +182,7 @@ mod tests {
     async fn agent_health_check() {
         let agent = MockAgent::new("test-agent");
         let health = agent.health().await;
-        
+
         match health {
             HealthStatus::Healthy => {
                 // Expected for new agent
@@ -171,14 +195,29 @@ mod tests {
     fn agent_config_access() {
         let agent = MockAgent::new("test-agent");
         let config = agent.config();
-        
+
         // Test configuration constraints and business rules
         assert!(!config.name.is_empty(), "Agent name should not be empty");
-        assert!(config.max_concurrent_requests > 0, "Should allow at least one concurrent request");
-        assert!(config.max_concurrent_requests <= 100, "Should have reasonable concurrent request limit");
-        assert!(config.timeout_ms >= 1000, "Timeout should be at least 1 second");
-        assert!(config.timeout_ms <= 300000, "Timeout should not exceed 5 minutes");
-        assert!(!config.tools.is_empty(), "Agent should have at least one tool available");
+        assert!(
+            config.max_concurrent_requests > 0,
+            "Should allow at least one concurrent request"
+        );
+        assert!(
+            config.max_concurrent_requests <= 100,
+            "Should have reasonable concurrent request limit"
+        );
+        assert!(
+            config.timeout_ms >= 1000,
+            "Timeout should be at least 1 second"
+        );
+        assert!(
+            config.timeout_ms <= 300000,
+            "Timeout should not exceed 5 minutes"
+        );
+        assert!(
+            !config.tools.is_empty(),
+            "Agent should have at least one tool available"
+        );
     }
 
     // === TOOL TRAIT TESTS ===
@@ -186,16 +225,25 @@ mod tests {
     #[test]
     fn tool_metadata_access() {
         let tool = MockTool::new("test-tool");
-        
+
         // Test tool contract requirements
         assert!(!tool.name().is_empty(), "Tool name should not be empty");
-        assert!(!tool.description().is_empty(), "Tool description should not be empty");
-        
+        assert!(
+            !tool.description().is_empty(),
+            "Tool description should not be empty"
+        );
+
         let schema = tool.parameters_schema();
-        assert!(schema.is_object(), "Parameters schema should be a JSON object");
+        assert!(
+            schema.is_object(),
+            "Parameters schema should be a JSON object"
+        );
         assert!(schema.get("type").is_some(), "Schema should specify type");
-        assert!(schema.get("properties").is_some(), "Schema should have properties");
-        
+        assert!(
+            schema.get("properties").is_some(),
+            "Schema should have properties"
+        );
+
         let metadata = tool.metadata();
         assert!(!metadata.category.is_empty(), "Tool should have a category");
         assert!(!metadata.version.is_empty(), "Tool should have a version");
@@ -205,91 +253,152 @@ mod tests {
     #[tokio::test]
     async fn tool_execute_with_params() {
         let tool = MockTool::new("test-tool");
-        
+
         let params = ToolParams {
             call_id: "call-123".to_string(),
             parameters: serde_json::json!({ "input": "test" }),
             context: HashMap::new(),
         };
-        
+
         let result = tool.execute(params).await;
-        assert!(result.is_ok(), "Tool execution should succeed with valid parameters");
-        
+        assert!(
+            result.is_ok(),
+            "Tool execution should succeed with valid parameters"
+        );
+
         let tool_result = result.expect("Tool execution should succeed");
-        
+
         // Test that tool properly preserves call correlation
-        assert_eq!(tool_result.call_id, "call-123", "Call ID should be preserved for tracing");
-        assert!(tool_result.success, "Valid parameters should result in successful execution");
-        assert!(tool_result.error.is_none(), "Successful execution should not have error message");
-        
+        assert_eq!(
+            tool_result.call_id, "call-123",
+            "Call ID should be preserved for tracing"
+        );
+        assert!(
+            tool_result.success,
+            "Valid parameters should result in successful execution"
+        );
+        assert!(
+            tool_result.error.is_none(),
+            "Successful execution should not have error message"
+        );
+
         // Test that tool actually processes the input rather than just echoing
-        assert!(!tool_result.data.is_null(), "Tool should return meaningful data");
+        assert!(
+            !tool_result.data.is_null(),
+            "Tool should return meaningful data"
+        );
         if let Some(output) = tool_result.data.get("output") {
             if let Some(output_str) = output.as_str() {
-                assert!(output_str.contains("Mock processed"), "Tool should process input, not just return it");
-                assert!(output_str.contains("test"), "Output should include original input");
+                assert!(
+                    output_str.contains("Mock processed"),
+                    "Tool should process input, not just return it"
+                );
+                assert!(
+                    output_str.contains("test"),
+                    "Output should include original input"
+                );
             }
         }
-        
+
         // Test metadata initialization
-        assert!(tool_result.metadata.is_empty() || !tool_result.metadata.is_empty(), "Metadata should be initialized");
+        assert!(
+            tool_result.metadata.is_empty() || !tool_result.metadata.is_empty(),
+            "Metadata should be initialized"
+        );
     }
 
     #[tokio::test]
     async fn tool_execute_with_invalid_params() {
         let tool = MockTool::new("test-tool");
-        
+
         // Test with completely wrong parameter structure
         let wrong_params = ToolParams {
             call_id: "call-456".to_string(),
             parameters: serde_json::json!({ "invalid": true }),
             context: HashMap::new(),
         };
-        
+
         let result = tool.execute(wrong_params).await;
         // Tool should handle invalid params gracefully and provide useful feedback
         match result {
             Ok(tool_result) => {
-                assert_eq!(tool_result.call_id, "call-456", "Call ID should be preserved even for failures");
-                assert!(!tool_result.success, "Invalid parameters should result in failure");
-                assert!(tool_result.error.is_some(), "Failure should include descriptive error message");
-                
+                assert_eq!(
+                    tool_result.call_id, "call-456",
+                    "Call ID should be preserved even for failures"
+                );
+                assert!(
+                    !tool_result.success,
+                    "Invalid parameters should result in failure"
+                );
+                assert!(
+                    tool_result.error.is_some(),
+                    "Failure should include descriptive error message"
+                );
+
                 if let Some(error_msg) = tool_result.error {
-                    assert!(error_msg.contains("Missing required parameter"), "Error should be specific");
-                    assert!(error_msg.contains("input"), "Error should mention missing parameter name");
+                    assert!(
+                        error_msg.contains("Missing required parameter"),
+                        "Error should be specific"
+                    );
+                    assert!(
+                        error_msg.contains("input"),
+                        "Error should mention missing parameter name"
+                    );
                 }
-                
-                assert_eq!(tool_result.data, serde_json::json!({}), "Failed execution should return empty data");
+
+                assert_eq!(
+                    tool_result.data,
+                    serde_json::json!({}),
+                    "Failed execution should return empty data"
+                );
             }
             Err(e) => {
                 // Also acceptable to return PatinoxError for validation failures
                 // This would indicate tool-level parameter validation
-                panic!("Tool should handle parameter validation gracefully, not return error: {:?}", e);
+                panic!(
+                    "Tool should handle parameter validation gracefully, not return error: {:?}",
+                    e
+                );
             }
         }
-        
+
         // Test with empty parameters
         let empty_params = ToolParams {
             call_id: "empty-call".to_string(),
             parameters: serde_json::json!({}),
             context: HashMap::new(),
         };
-        
-        let empty_result = tool.execute(empty_params).await.expect("Should handle empty params gracefully");
-        assert!(!empty_result.success, "Empty parameters should fail validation");
-        assert!(empty_result.error.is_some(), "Should provide error message for empty parameters");
-        
+
+        let empty_result = tool
+            .execute(empty_params)
+            .await
+            .expect("Should handle empty params gracefully");
+        assert!(
+            !empty_result.success,
+            "Empty parameters should fail validation"
+        );
+        assert!(
+            empty_result.error.is_some(),
+            "Should provide error message for empty parameters"
+        );
+
         // Test parameter type validation
         let wrong_type_params = ToolParams {
             call_id: "type-test".to_string(),
             parameters: serde_json::json!({ "input": 123 }), // Should be string
             context: HashMap::new(),
         };
-        
-        let type_result = tool.execute(wrong_type_params).await.expect("Should handle wrong types gracefully");
+
+        let type_result = tool
+            .execute(wrong_type_params)
+            .await
+            .expect("Should handle wrong types gracefully");
         // Tool should either convert or reject - both are valid behaviors
         if !type_result.success {
-            assert!(type_result.error.is_some(), "Type validation failure should include error");
+            assert!(
+                type_result.error.is_some(),
+                "Type validation failure should include error"
+            );
         }
     }
 
@@ -298,9 +407,9 @@ mod tests {
     #[test]
     fn validator_configuration() {
         let validator = MockValidator::new("test-validator");
-        
+
         assert_eq!(validator.name(), "test-validator");
-        
+
         let config = validator.config();
         assert_eq!(config.name, "test-validator");
         assert!(!config.stages.is_empty());
@@ -309,7 +418,7 @@ mod tests {
     #[test]
     fn validator_should_validate_logic() {
         let validator = MockValidator::new("test-validator");
-        
+
         let request = ValidationRequest {
             agent_id: Uuid::new_v4(),
             request_id: Uuid::new_v4(),
@@ -319,15 +428,15 @@ mod tests {
             },
             context: HashMap::new(),
         };
-        
+
         // Should validate PreExecution stage
         assert!(validator.should_validate(&request));
-        
+
         let request_post = ValidationRequest {
             stage: ValidationStage::PostTool,
             ..request
         };
-        
+
         // Should not validate PostTool stage (based on config)
         assert!(!validator.should_validate(&request_post));
     }
@@ -335,7 +444,7 @@ mod tests {
     #[tokio::test]
     async fn validator_async_interface() {
         let validator = MockValidator::new("test-validator");
-        
+
         let request = ValidationRequest {
             agent_id: Uuid::new_v4(),
             request_id: Uuid::new_v4(),
@@ -345,10 +454,10 @@ mod tests {
             },
             context: HashMap::new(),
         };
-        
+
         let response = validator.validate(request).await;
         assert!(response.is_ok(), "Validator should validate safe content");
-        
+
         let validation_response = response.expect("Validation should succeed");
         assert!(validation_response.approved);
     }
@@ -358,14 +467,14 @@ mod tests {
     #[tokio::test]
     async fn monitor_execution_lifecycle() {
         let monitor = MockMonitor::new("test-monitor");
-        
+
         let execution_id = Uuid::new_v4();
         let agent_id = Uuid::new_v4();
-        
+
         // Start monitoring
         let result = monitor.start_monitoring(execution_id, agent_id).await;
         assert!(result.is_ok(), "Monitor should start monitoring");
-        
+
         // Record an event
         let event = MonitorEvent {
             id: Uuid::new_v4(),
@@ -376,10 +485,10 @@ mod tests {
             data: serde_json::json!({}),
             metadata: HashMap::new(),
         };
-        
+
         let result = monitor.record_event(event).await;
         assert!(result.is_ok(), "Monitor should record events");
-        
+
         // Complete monitoring
         let summary = ExecutionSummary {
             execution_id,
@@ -397,7 +506,7 @@ mod tests {
             },
             error_summary: None,
         };
-        
+
         let result = monitor.complete_monitoring(execution_id, summary).await;
         assert!(result.is_ok(), "Monitor should complete monitoring");
     }
@@ -405,7 +514,7 @@ mod tests {
     #[tokio::test]
     async fn monitor_query_events() {
         let monitor = MockMonitor::new("test-monitor");
-        
+
         let query = MonitorQuery {
             agent_ids: None,
             event_types: Some(vec![MonitorEventType::ExecutionStarted]),
@@ -413,10 +522,10 @@ mod tests {
             end_time: None,
             limit: Some(10),
         };
-        
+
         let result = monitor.query_events(query).await;
         assert!(result.is_ok(), "Monitor should handle queries");
-        
+
         let _events = result.expect("Monitor query should succeed");
         // For mock implementation, might return empty or sample data
     }
@@ -425,7 +534,7 @@ mod tests {
     fn monitor_config_access() {
         let monitor = MockMonitor::new("test-monitor");
         let config = monitor.config();
-        
+
         assert_eq!(config.name, "test-monitor");
         assert!(config.enabled);
         assert!(config.buffer_size > 0);
@@ -440,16 +549,16 @@ mod tests {
         // These functions verify that trait objects are Send + Sync
         fn assert_send<T: Send>() {}
         fn assert_sync<T: Sync>() {}
-        
+
         assert_send::<Box<dyn Agent>>();
         assert_sync::<Box<dyn Agent>>();
-        
+
         assert_send::<Box<dyn Tool>>();
         assert_sync::<Box<dyn Tool>>();
-        
+
         assert_send::<Box<dyn Validator>>();
         assert_sync::<Box<dyn Validator>>();
-        
+
         assert_send::<Box<dyn Monitor>>();
         assert_sync::<Box<dyn Monitor>>();
     }
@@ -460,7 +569,7 @@ mod tests {
     async fn agent_handles_empty_message_request() {
         let mut agent = MockAgent::new("error-test");
         agent.start().await.expect("Agent should start");
-        
+
         let empty_request = AgentRequest {
             id: Uuid::new_v4(),
             user_id: Some("user123".to_string()),
@@ -469,12 +578,15 @@ mod tests {
             context: HashMap::new(),
             metadata: HashMap::new(),
         };
-        
+
         // Agent should handle empty messages gracefully
         let result = agent.execute(empty_request).await;
         match result {
             Ok(response) => {
-                assert!(!response.message.is_empty(), "Agent should provide meaningful response to empty input");
+                assert!(
+                    !response.message.is_empty(),
+                    "Agent should provide meaningful response to empty input"
+                );
             }
             Err(PatinoxError::Validation(_)) => {
                 // Also acceptable - agent rejects empty input
@@ -486,7 +598,7 @@ mod tests {
     #[tokio::test]
     async fn validator_handles_malformed_content() {
         let validator = MockValidator::new("malformed-test");
-        
+
         let malformed_request = ValidationRequest {
             agent_id: Uuid::new_v4(),
             request_id: Uuid::new_v4(),
@@ -496,7 +608,7 @@ mod tests {
             },
             context: HashMap::new(),
         };
-        
+
         let result = validator.validate(malformed_request).await;
         match result {
             Ok(response) => {
@@ -514,18 +626,18 @@ mod tests {
     #[tokio::test]
     async fn traits_use_patinox_error() {
         let mut agent = MockAgent::new("error-test");
-        
+
         // Test that Agent methods return PatinoxError
         let start_result: Result<(), PatinoxError> = agent.start().await;
         assert!(start_result.is_ok());
-        
+
         let tool = MockTool::new("error-test");
         let params = ToolParams {
             call_id: "error-test".to_string(),
             parameters: serde_json::json!({}),
             context: HashMap::new(),
         };
-        
+
         // Test that Tool execute returns PatinoxError
         let execute_result: Result<ToolResult, PatinoxError> = tool.execute(params).await;
         assert!(execute_result.is_ok());
@@ -561,39 +673,55 @@ mod tests {
 
     #[async_trait]
     impl Agent for MockAgent {
-        fn id(&self) -> Uuid { self.id }
-        fn state(&self) -> AgentState { self.state.clone() }
-        fn config(&self) -> &AgentConfig { &self.config }
-        
+        fn id(&self) -> Uuid {
+            self.id
+        }
+        fn state(&self) -> AgentState {
+            self.state.clone()
+        }
+        fn config(&self) -> &AgentConfig {
+            &self.config
+        }
+
         async fn start(&mut self) -> Result<(), PatinoxError> {
             self.state = AgentState::Running;
             Ok(())
         }
-        
+
         async fn stop(&mut self) -> Result<(), PatinoxError> {
             self.state = AgentState::Stopped;
             Ok(())
         }
-        
+
         async fn execute(&mut self, request: AgentRequest) -> Result<AgentResponse, PatinoxError> {
             if !matches!(self.state, AgentState::Running) {
                 return Err(PatinoxError::Execution(
                     crate::error::ExecutionError::AgentStateMismatch(
-                        "Running".to_string(), format!("{:?}", self.state)
-                    )
+                        "Running".to_string(),
+                        format!("{:?}", self.state),
+                    ),
                 ));
             }
             Ok(AgentResponse {
                 request_id: request.id,
                 message: format!("Mock response to: {}", request.message),
                 tool_results: vec![],
-                usage: Usage { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15, cost_usd: Some(0.001) },
+                usage: Usage {
+                    prompt_tokens: 10,
+                    completion_tokens: 5,
+                    total_tokens: 15,
+                    cost_usd: Some(0.001),
+                },
                 metadata: HashMap::new(),
             })
         }
-        
-        fn available_tools(&self) -> Vec<String> { vec!["mock-tool".to_string()] }
-        async fn health(&self) -> HealthStatus { HealthStatus::Healthy }
+
+        fn available_tools(&self) -> Vec<String> {
+            vec!["mock-tool".to_string()]
+        }
+        async fn health(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
     }
 
     pub struct MockTool {
@@ -602,15 +730,21 @@ mod tests {
 
     impl MockTool {
         pub fn new(name: &str) -> Self {
-            Self { name: name.to_string() }
+            Self {
+                name: name.to_string(),
+            }
         }
     }
 
     #[async_trait]
     impl Tool for MockTool {
-        fn name(&self) -> &str { &self.name }
-        fn description(&self) -> &str { "Mock tool for testing" }
-        
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn description(&self) -> &str {
+            "Mock tool for testing"
+        }
+
         fn parameters_schema(&self) -> serde_json::Value {
             serde_json::json!({
                 "type": "object",
@@ -620,7 +754,7 @@ mod tests {
                 "required": ["input"]
             })
         }
-        
+
         async fn execute(&self, params: ToolParams) -> Result<ToolResult, PatinoxError> {
             let input = params.parameters.get("input");
             if input.is_none() {
@@ -640,7 +774,7 @@ mod tests {
                 metadata: HashMap::new(),
             })
         }
-        
+
         fn metadata(&self) -> ToolMetadata {
             ToolMetadata {
                 category: "mock".to_string(),
@@ -672,17 +806,23 @@ mod tests {
         }
     }
 
-
     #[async_trait]
     impl Validator for MockValidator {
-        fn name(&self) -> &str { &self.name }
-        fn config(&self) -> &ValidatorConfig { &self.config }
-        
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn config(&self) -> &ValidatorConfig {
+            &self.config
+        }
+
         fn should_validate(&self, request: &ValidationRequest) -> bool {
             self.config.stages.contains(&request.stage)
         }
 
-        async fn validate(&self, request: ValidationRequest) -> Result<ValidationResponse, PatinoxError> {
+        async fn validate(
+            &self,
+            request: ValidationRequest,
+        ) -> Result<ValidationResponse, PatinoxError> {
             match &request.content {
                 ValidationContent::UserMessage { message } => {
                     if message.contains("unsafe") {
@@ -700,13 +840,13 @@ mod tests {
                             metadata: HashMap::new(),
                         })
                     }
-                },
+                }
                 _ => Ok(ValidationResponse {
                     approved: true,
                     reason: None,
                     modifications: None,
                     metadata: HashMap::new(),
-                })
+                }),
             }
         }
     }
@@ -736,9 +876,15 @@ mod tests {
 
     #[async_trait]
     impl Monitor for MockMonitor {
-        fn name(&self) -> &str { &self.name }
+        fn name(&self) -> &str {
+            &self.name
+        }
 
-        async fn start_monitoring(&self, execution_id: Uuid, agent_id: Uuid) -> Result<(), PatinoxError> {
+        async fn start_monitoring(
+            &self,
+            execution_id: Uuid,
+            agent_id: Uuid,
+        ) -> Result<(), PatinoxError> {
             let event = MonitorEvent {
                 id: Uuid::new_v4(),
                 execution_id,
@@ -748,24 +894,34 @@ mod tests {
                 data: serde_json::json!({}),
                 metadata: HashMap::new(),
             };
-            self.events.lock().map_err(|_| {
-                PatinoxError::Execution(crate::error::ExecutionError::ResourceExhausted(
-                    "Monitor event storage corrupted".to_string()
-                ))
-            })?.push(event);
+            self.events
+                .lock()
+                .map_err(|_| {
+                    PatinoxError::Execution(crate::error::ExecutionError::ResourceExhausted(
+                        "Monitor event storage corrupted".to_string(),
+                    ))
+                })?
+                .push(event);
             Ok(())
         }
 
         async fn record_event(&self, event: MonitorEvent) -> Result<(), PatinoxError> {
-            self.events.lock().map_err(|_| {
-                PatinoxError::Execution(crate::error::ExecutionError::ResourceExhausted(
-                    "Monitor event storage corrupted".to_string()
-                ))
-            })?.push(event);
+            self.events
+                .lock()
+                .map_err(|_| {
+                    PatinoxError::Execution(crate::error::ExecutionError::ResourceExhausted(
+                        "Monitor event storage corrupted".to_string(),
+                    ))
+                })?
+                .push(event);
             Ok(())
         }
 
-        async fn complete_monitoring(&self, execution_id: Uuid, summary: ExecutionSummary) -> Result<(), PatinoxError> {
+        async fn complete_monitoring(
+            &self,
+            execution_id: Uuid,
+            summary: ExecutionSummary,
+        ) -> Result<(), PatinoxError> {
             let event = MonitorEvent {
                 id: Uuid::new_v4(),
                 execution_id,
@@ -778,37 +934,56 @@ mod tests {
                 data: serde_json::to_value(&summary).unwrap(),
                 metadata: HashMap::new(),
             };
-            self.events.lock().map_err(|_| {
-                PatinoxError::Execution(crate::error::ExecutionError::ResourceExhausted(
-                    "Monitor event storage corrupted".to_string()
-                ))
-            })?.push(event);
+            self.events
+                .lock()
+                .map_err(|_| {
+                    PatinoxError::Execution(crate::error::ExecutionError::ResourceExhausted(
+                        "Monitor event storage corrupted".to_string(),
+                    ))
+                })?
+                .push(event);
             Ok(())
         }
 
-        async fn query_events(&self, _query: MonitorQuery) -> Result<Vec<MonitorEvent>, PatinoxError> {
-            Ok(self.events.lock().map_err(|_| {
-                PatinoxError::Execution(crate::error::ExecutionError::ResourceExhausted(
-                    "Monitor event storage corrupted".to_string()
-                ))
-            })?.clone())
+        async fn query_events(
+            &self,
+            _query: MonitorQuery,
+        ) -> Result<Vec<MonitorEvent>, PatinoxError> {
+            Ok(self
+                .events
+                .lock()
+                .map_err(|_| {
+                    PatinoxError::Execution(crate::error::ExecutionError::ResourceExhausted(
+                        "Monitor event storage corrupted".to_string(),
+                    ))
+                })?
+                .clone())
         }
 
-        fn config(&self) -> &MonitorConfig { &self.config }
+        fn config(&self) -> &MonitorConfig {
+            &self.config
+        }
     }
 }
 
 // Module structure - traits will be implemented in separate files
 pub mod agent;
+pub mod monitor;
 pub mod tool;
 pub mod validator;
-pub mod monitor;
 
 // Re-export core traits for convenience
-pub use agent::{Agent, AgentState, AgentConfig, AgentRequest, AgentResponse, HealthStatus, AgentBuilder};
-pub use tool::{Tool, ToolCall, ToolParams, ToolResult, ToolMetadata};
-pub use validator::{Validator, ValidationRequest, ValidationResponse, ValidationStage, ValidationContent, ValidatorConfig, ValidationModifications};
-pub use monitor::{Monitor, MonitorEvent, MonitorEventType, ExecutionSummary, MonitorQuery, MonitorConfig};
+pub use agent::{
+    Agent, AgentBuilder, AgentConfig, AgentRequest, AgentResponse, AgentState, HealthStatus,
+};
+pub use monitor::{
+    ExecutionSummary, Monitor, MonitorConfig, MonitorEvent, MonitorEventType, MonitorQuery,
+};
+pub use tool::{Tool, ToolCall, ToolMetadata, ToolParams, ToolResult};
+pub use validator::{
+    ValidationContent, ValidationModifications, ValidationRequest, ValidationResponse,
+    ValidationStage, Validator, ValidatorConfig,
+};
 
 // Supporting types used across traits
 use serde::{Deserialize, Serialize};

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -247,7 +247,10 @@ mod tests {
         let metadata = tool.metadata();
         assert!(!metadata.category.is_empty(), "Tool should have a category");
         assert!(!metadata.version.is_empty(), "Tool should have a version");
-        assert!(!metadata.tags.is_empty(), "Tool should have at least one tag");
+        assert!(
+            !metadata.tags.is_empty(),
+            "Tool should have at least one tag"
+        );
     }
 
     #[tokio::test]

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,0 +1,822 @@
+//! Core trait definitions for the Patinox framework
+//!
+//! This module contains the fundamental trait abstractions that define
+//! the contracts for all Patinox components: Agent, Tool, Validator, and Monitor.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::PatinoxError;
+    use async_trait::async_trait;
+    use std::collections::HashMap;
+    use uuid::Uuid;
+
+    // === TRAIT OBJECT SAFETY TESTS (Write these FIRST) ===
+
+    #[test]
+    fn agent_trait_is_object_safe() {
+        // This test will compile if Agent trait is object-safe
+        // We create a vector of trait objects to verify object safety
+        
+        #[allow(dead_code)]
+        fn accepts_agent_trait_object(_agent: Box<dyn Agent>) {
+            // Function that accepts a trait object
+        }
+        
+        // If this compiles, the trait is object-safe
+        // We'll implement MockAgent to make this pass
+    }
+
+    #[test]
+    fn tool_trait_is_object_safe() {
+        #[allow(dead_code)]
+        fn accepts_tool_trait_object(_tool: Box<dyn Tool>) {
+            // Function that accepts a trait object
+        }
+        
+        // Vector of trait objects to verify object safety
+        let _tools: Vec<Box<dyn Tool>> = Vec::new();
+    }
+
+    #[test]
+    fn validator_trait_is_object_safe() {
+        #[allow(dead_code)]
+        fn accepts_validator_trait_object(_validator: Box<dyn Validator>) {
+            // Function that accepts a trait object
+        }
+        
+        // Vector of trait objects to verify object safety
+        let _validators: Vec<Box<dyn Validator>> = Vec::new();
+    }
+
+    #[test]
+    fn monitor_trait_is_object_safe() {
+        #[allow(dead_code)]
+        fn accepts_monitor_trait_object(_monitor: Box<dyn Monitor>) {
+            // Function that accepts a trait object
+        }
+        
+        // Vector of trait objects to verify object safety
+        let _monitors: Vec<Box<dyn Monitor>> = Vec::new();
+    }
+
+    // === AGENT TRAIT TESTS ===
+
+    #[tokio::test]
+    async fn agent_lifecycle_state_transitions() {
+        let mut agent = MockAgent::new("test-agent");
+        
+        // Initial state should be Created and agent should not be executable
+        assert_eq!(agent.state(), AgentState::Created);
+        
+        // Test that agent cannot execute in Created state
+        let test_request = AgentRequest {
+            id: Uuid::new_v4(),
+            user_id: Some("user123".to_string()),
+            message: "test".to_string(),
+            tool_calls: vec![],
+            context: HashMap::new(),
+            metadata: HashMap::new(),
+        };
+        
+        let initial_result = agent.execute(test_request.clone()).await;
+        assert!(initial_result.is_err(), "Agent should not execute in Created state");
+        
+        // Start the agent and verify it becomes executable
+        agent.start().await.expect("Agent should start successfully");
+        assert_eq!(agent.state(), AgentState::Running);
+        
+        // Test that agent can execute in Running state
+        let running_result = agent.execute(test_request.clone()).await;
+        assert!(running_result.is_ok(), "Agent should execute in Running state");
+        
+        // Stop the agent and verify it becomes non-executable again
+        agent.stop().await.expect("Agent should stop successfully");
+        assert_eq!(agent.state(), AgentState::Stopped);
+        
+        // Test that agent cannot execute in Stopped state
+        let stopped_result = agent.execute(test_request).await;
+        assert!(stopped_result.is_err(), "Agent should not execute in Stopped state");
+        
+        // Test multiple start/stop cycles work correctly
+        agent.start().await.expect("Agent should restart from Stopped");
+        assert_eq!(agent.state(), AgentState::Running);
+        
+        agent.stop().await.expect("Agent should stop again");
+        assert_eq!(agent.state(), AgentState::Stopped);
+    }
+
+    #[tokio::test]
+    async fn agent_has_unique_id() {
+        let agent1 = MockAgent::new("agent1");
+        let agent2 = MockAgent::new("agent2");
+        
+        assert_ne!(agent1.id(), agent2.id(), "Each agent should have unique ID");
+    }
+
+    #[tokio::test]
+    async fn agent_execute_requires_running_state() {
+        let mut agent = MockAgent::new("test-agent");
+        
+        let request = AgentRequest {
+            id: Uuid::new_v4(),
+            user_id: Some("user123".to_string()),
+            message: "Hello".to_string(),
+            tool_calls: vec![],
+            context: HashMap::new(),
+            metadata: HashMap::new(),
+        };
+        
+        // Should fail when not started
+        let result = agent.execute(request.clone()).await;
+        assert!(result.is_err(), "Execute should fail when agent not started");
+        
+        // Should succeed when started
+        agent.start().await.expect("Agent should start");
+        let result = agent.execute(request).await;
+        assert!(result.is_ok(), "Execute should succeed when agent is running");
+    }
+
+    #[tokio::test]
+    async fn agent_available_tools_list() {
+        let agent = MockAgent::new("test-agent");
+        let tools = agent.available_tools();
+        
+        // Test that agent provides tools list (contract requirement)
+        assert!(!tools.is_empty(), "Agent should have available tools");
+        // Test that all tool names are valid (non-empty strings)
+        for tool in &tools {
+            assert!(!tool.is_empty(), "Tool names should not be empty");
+            assert!(!tool.chars().all(|c| c.is_whitespace()), "Tool names should not be only whitespace");
+        }
+        // Test that tools list is deterministic (same agent returns same tools)
+        let tools2 = agent.available_tools();
+        assert_eq!(tools, tools2, "available_tools() should be deterministic");
+    }
+
+    #[tokio::test]
+    async fn agent_health_check() {
+        let agent = MockAgent::new("test-agent");
+        let health = agent.health().await;
+        
+        match health {
+            HealthStatus::Healthy => {
+                // Expected for new agent
+            }
+            _ => panic!("New agent should be healthy"),
+        }
+    }
+
+    #[test]
+    fn agent_config_access() {
+        let agent = MockAgent::new("test-agent");
+        let config = agent.config();
+        
+        // Test configuration constraints and business rules
+        assert!(!config.name.is_empty(), "Agent name should not be empty");
+        assert!(config.max_concurrent_requests > 0, "Should allow at least one concurrent request");
+        assert!(config.max_concurrent_requests <= 100, "Should have reasonable concurrent request limit");
+        assert!(config.timeout_ms >= 1000, "Timeout should be at least 1 second");
+        assert!(config.timeout_ms <= 300000, "Timeout should not exceed 5 minutes");
+        assert!(!config.tools.is_empty(), "Agent should have at least one tool available");
+    }
+
+    // === TOOL TRAIT TESTS ===
+
+    #[test]
+    fn tool_metadata_access() {
+        let tool = MockTool::new("test-tool");
+        
+        // Test tool contract requirements
+        assert!(!tool.name().is_empty(), "Tool name should not be empty");
+        assert!(!tool.description().is_empty(), "Tool description should not be empty");
+        
+        let schema = tool.parameters_schema();
+        assert!(schema.is_object(), "Parameters schema should be a JSON object");
+        assert!(schema.get("type").is_some(), "Schema should specify type");
+        assert!(schema.get("properties").is_some(), "Schema should have properties");
+        
+        let metadata = tool.metadata();
+        assert!(!metadata.category.is_empty(), "Tool should have a category");
+        assert!(!metadata.version.is_empty(), "Tool should have a version");
+        assert!(metadata.tags.len() > 0, "Tool should have at least one tag");
+    }
+
+    #[tokio::test]
+    async fn tool_execute_with_params() {
+        let tool = MockTool::new("test-tool");
+        
+        let params = ToolParams {
+            call_id: "call-123".to_string(),
+            parameters: serde_json::json!({ "input": "test" }),
+            context: HashMap::new(),
+        };
+        
+        let result = tool.execute(params).await;
+        assert!(result.is_ok(), "Tool execution should succeed with valid parameters");
+        
+        let tool_result = result.expect("Tool execution should succeed");
+        
+        // Test that tool properly preserves call correlation
+        assert_eq!(tool_result.call_id, "call-123", "Call ID should be preserved for tracing");
+        assert!(tool_result.success, "Valid parameters should result in successful execution");
+        assert!(tool_result.error.is_none(), "Successful execution should not have error message");
+        
+        // Test that tool actually processes the input rather than just echoing
+        assert!(!tool_result.data.is_null(), "Tool should return meaningful data");
+        if let Some(output) = tool_result.data.get("output") {
+            if let Some(output_str) = output.as_str() {
+                assert!(output_str.contains("Mock processed"), "Tool should process input, not just return it");
+                assert!(output_str.contains("test"), "Output should include original input");
+            }
+        }
+        
+        // Test metadata initialization
+        assert!(tool_result.metadata.is_empty() || !tool_result.metadata.is_empty(), "Metadata should be initialized");
+    }
+
+    #[tokio::test]
+    async fn tool_execute_with_invalid_params() {
+        let tool = MockTool::new("test-tool");
+        
+        // Test with completely wrong parameter structure
+        let wrong_params = ToolParams {
+            call_id: "call-456".to_string(),
+            parameters: serde_json::json!({ "invalid": true }),
+            context: HashMap::new(),
+        };
+        
+        let result = tool.execute(wrong_params).await;
+        // Tool should handle invalid params gracefully and provide useful feedback
+        match result {
+            Ok(tool_result) => {
+                assert_eq!(tool_result.call_id, "call-456", "Call ID should be preserved even for failures");
+                assert!(!tool_result.success, "Invalid parameters should result in failure");
+                assert!(tool_result.error.is_some(), "Failure should include descriptive error message");
+                
+                if let Some(error_msg) = tool_result.error {
+                    assert!(error_msg.contains("Missing required parameter"), "Error should be specific");
+                    assert!(error_msg.contains("input"), "Error should mention missing parameter name");
+                }
+                
+                assert_eq!(tool_result.data, serde_json::json!({}), "Failed execution should return empty data");
+            }
+            Err(e) => {
+                // Also acceptable to return PatinoxError for validation failures
+                // This would indicate tool-level parameter validation
+                panic!("Tool should handle parameter validation gracefully, not return error: {:?}", e);
+            }
+        }
+        
+        // Test with empty parameters
+        let empty_params = ToolParams {
+            call_id: "empty-call".to_string(),
+            parameters: serde_json::json!({}),
+            context: HashMap::new(),
+        };
+        
+        let empty_result = tool.execute(empty_params).await.expect("Should handle empty params gracefully");
+        assert!(!empty_result.success, "Empty parameters should fail validation");
+        assert!(empty_result.error.is_some(), "Should provide error message for empty parameters");
+        
+        // Test parameter type validation
+        let wrong_type_params = ToolParams {
+            call_id: "type-test".to_string(),
+            parameters: serde_json::json!({ "input": 123 }), // Should be string
+            context: HashMap::new(),
+        };
+        
+        let type_result = tool.execute(wrong_type_params).await.expect("Should handle wrong types gracefully");
+        // Tool should either convert or reject - both are valid behaviors
+        if !type_result.success {
+            assert!(type_result.error.is_some(), "Type validation failure should include error");
+        }
+    }
+
+    // === VALIDATOR TRAIT TESTS ===
+
+    #[test]
+    fn validator_configuration() {
+        let validator = MockValidator::new("test-validator");
+        
+        assert_eq!(validator.name(), "test-validator");
+        
+        let config = validator.config();
+        assert_eq!(config.name, "test-validator");
+        assert!(!config.stages.is_empty());
+    }
+
+    #[test]
+    fn validator_should_validate_logic() {
+        let validator = MockValidator::new("test-validator");
+        
+        let request = ValidationRequest {
+            agent_id: Uuid::new_v4(),
+            request_id: Uuid::new_v4(),
+            stage: ValidationStage::PreExecution,
+            content: ValidationContent::UserMessage {
+                message: "Hello".to_string(),
+            },
+            context: HashMap::new(),
+        };
+        
+        // Should validate PreExecution stage
+        assert!(validator.should_validate(&request));
+        
+        let request_post = ValidationRequest {
+            stage: ValidationStage::PostTool,
+            ..request
+        };
+        
+        // Should not validate PostTool stage (based on config)
+        assert!(!validator.should_validate(&request_post));
+    }
+
+    #[tokio::test]
+    async fn validator_async_interface() {
+        let validator = MockValidator::new("test-validator");
+        
+        let request = ValidationRequest {
+            agent_id: Uuid::new_v4(),
+            request_id: Uuid::new_v4(),
+            stage: ValidationStage::PreExecution,
+            content: ValidationContent::UserMessage {
+                message: "Safe message".to_string(),
+            },
+            context: HashMap::new(),
+        };
+        
+        let response = validator.validate(request).await;
+        assert!(response.is_ok(), "Validator should validate safe content");
+        
+        let validation_response = response.expect("Validation should succeed");
+        assert!(validation_response.approved);
+    }
+
+    // === MONITOR TRAIT TESTS ===
+
+    #[tokio::test]
+    async fn monitor_execution_lifecycle() {
+        let monitor = MockMonitor::new("test-monitor");
+        
+        let execution_id = Uuid::new_v4();
+        let agent_id = Uuid::new_v4();
+        
+        // Start monitoring
+        let result = monitor.start_monitoring(execution_id, agent_id).await;
+        assert!(result.is_ok(), "Monitor should start monitoring");
+        
+        // Record an event
+        let event = MonitorEvent {
+            id: Uuid::new_v4(),
+            execution_id,
+            agent_id,
+            timestamp: chrono::Utc::now(),
+            event_type: MonitorEventType::ExecutionStarted,
+            data: serde_json::json!({}),
+            metadata: HashMap::new(),
+        };
+        
+        let result = monitor.record_event(event).await;
+        assert!(result.is_ok(), "Monitor should record events");
+        
+        // Complete monitoring
+        let summary = ExecutionSummary {
+            execution_id,
+            agent_id,
+            success: true,
+            total_duration_ms: 1500,
+            llm_calls: 1,
+            tool_calls: 2,
+            validation_failures: 0,
+            total_tokens: Usage {
+                prompt_tokens: 100,
+                completion_tokens: 50,
+                total_tokens: 150,
+                cost_usd: Some(0.003),
+            },
+            error_summary: None,
+        };
+        
+        let result = monitor.complete_monitoring(execution_id, summary).await;
+        assert!(result.is_ok(), "Monitor should complete monitoring");
+    }
+
+    #[tokio::test]
+    async fn monitor_query_events() {
+        let monitor = MockMonitor::new("test-monitor");
+        
+        let query = MonitorQuery {
+            agent_ids: None,
+            event_types: Some(vec![MonitorEventType::ExecutionStarted]),
+            start_time: None,
+            end_time: None,
+            limit: Some(10),
+        };
+        
+        let result = monitor.query_events(query).await;
+        assert!(result.is_ok(), "Monitor should handle queries");
+        
+        let _events = result.expect("Monitor query should succeed");
+        // For mock implementation, might return empty or sample data
+    }
+
+    #[test]
+    fn monitor_config_access() {
+        let monitor = MockMonitor::new("test-monitor");
+        let config = monitor.config();
+        
+        assert_eq!(config.name, "test-monitor");
+        assert!(config.enabled);
+        assert!(config.buffer_size > 0);
+        assert!(config.flush_interval_ms > 0);
+        assert!(config.sampling_rate >= 0.0 && config.sampling_rate <= 1.0);
+    }
+
+    // === SEND + SYNC TESTS ===
+
+    #[test]
+    fn all_traits_are_send_sync() {
+        // These functions verify that trait objects are Send + Sync
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+        
+        assert_send::<Box<dyn Agent>>();
+        assert_sync::<Box<dyn Agent>>();
+        
+        assert_send::<Box<dyn Tool>>();
+        assert_sync::<Box<dyn Tool>>();
+        
+        assert_send::<Box<dyn Validator>>();
+        assert_sync::<Box<dyn Validator>>();
+        
+        assert_send::<Box<dyn Monitor>>();
+        assert_sync::<Box<dyn Monitor>>();
+    }
+
+    // === ERROR INTEGRATION TESTS ===
+
+    #[tokio::test]
+    async fn agent_handles_empty_message_request() {
+        let mut agent = MockAgent::new("error-test");
+        agent.start().await.expect("Agent should start");
+        
+        let empty_request = AgentRequest {
+            id: Uuid::new_v4(),
+            user_id: Some("user123".to_string()),
+            message: "".to_string(), // Empty message
+            tool_calls: vec![],
+            context: HashMap::new(),
+            metadata: HashMap::new(),
+        };
+        
+        // Agent should handle empty messages gracefully
+        let result = agent.execute(empty_request).await;
+        match result {
+            Ok(response) => {
+                assert!(!response.message.is_empty(), "Agent should provide meaningful response to empty input");
+            }
+            Err(PatinoxError::Validation(_)) => {
+                // Also acceptable - agent rejects empty input
+            }
+            Err(e) => panic!("Unexpected error type for empty message: {:?}", e),
+        }
+    }
+
+    #[tokio::test]
+    async fn validator_handles_malformed_content() {
+        let validator = MockValidator::new("malformed-test");
+        
+        let malformed_request = ValidationRequest {
+            agent_id: Uuid::new_v4(),
+            request_id: Uuid::new_v4(),
+            stage: ValidationStage::PreExecution,
+            content: ValidationContent::UserMessage {
+                message: "test\x00\x01malformed".to_string(), // Contains null bytes
+            },
+            context: HashMap::new(),
+        };
+        
+        let result = validator.validate(malformed_request).await;
+        match result {
+            Ok(response) => {
+                // Validator should handle malformed input gracefully
+                if !response.approved {
+                    assert!(response.reason.is_some(), "Rejection should include reason");
+                }
+            }
+            Err(_) => {
+                // Also acceptable - validator rejects malformed input
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn traits_use_patinox_error() {
+        let mut agent = MockAgent::new("error-test");
+        
+        // Test that Agent methods return PatinoxError
+        let start_result: Result<(), PatinoxError> = agent.start().await;
+        assert!(start_result.is_ok());
+        
+        let tool = MockTool::new("error-test");
+        let params = ToolParams {
+            call_id: "error-test".to_string(),
+            parameters: serde_json::json!({}),
+            context: HashMap::new(),
+        };
+        
+        // Test that Tool execute returns PatinoxError
+        let execute_result: Result<ToolResult, PatinoxError> = tool.execute(params).await;
+        assert!(execute_result.is_ok());
+    }
+
+    // Mock implementations for testing
+
+    pub struct MockAgent {
+        id: Uuid,
+        state: AgentState,
+        config: AgentConfig,
+    }
+
+    impl MockAgent {
+        pub fn new(name: &str) -> Self {
+            Self {
+                id: Uuid::new_v4(),
+                state: AgentState::Created,
+                config: AgentConfig {
+                    name: name.to_string(),
+                    description: Some("Mock agent".to_string()),
+                    max_concurrent_requests: 5,
+                    timeout_ms: 30000,
+                    enabled_validators: vec!["mock-validator".to_string()],
+                    llm_provider: "mock".to_string(),
+                    llm_model: "mock-model".to_string(),
+                    tools: vec!["mock-tool".to_string()],
+                    metadata: HashMap::new(),
+                },
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Agent for MockAgent {
+        fn id(&self) -> Uuid { self.id }
+        fn state(&self) -> AgentState { self.state.clone() }
+        fn config(&self) -> &AgentConfig { &self.config }
+        
+        async fn start(&mut self) -> Result<(), PatinoxError> {
+            self.state = AgentState::Running;
+            Ok(())
+        }
+        
+        async fn stop(&mut self) -> Result<(), PatinoxError> {
+            self.state = AgentState::Stopped;
+            Ok(())
+        }
+        
+        async fn execute(&mut self, request: AgentRequest) -> Result<AgentResponse, PatinoxError> {
+            if !matches!(self.state, AgentState::Running) {
+                return Err(PatinoxError::Execution(
+                    crate::error::ExecutionError::AgentStateMismatch(
+                        "Running".to_string(), format!("{:?}", self.state)
+                    )
+                ));
+            }
+            Ok(AgentResponse {
+                request_id: request.id,
+                message: format!("Mock response to: {}", request.message),
+                tool_results: vec![],
+                usage: Usage { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15, cost_usd: Some(0.001) },
+                metadata: HashMap::new(),
+            })
+        }
+        
+        fn available_tools(&self) -> Vec<String> { vec!["mock-tool".to_string()] }
+        async fn health(&self) -> HealthStatus { HealthStatus::Healthy }
+    }
+
+    pub struct MockTool {
+        name: String,
+    }
+
+    impl MockTool {
+        pub fn new(name: &str) -> Self {
+            Self { name: name.to_string() }
+        }
+    }
+
+    #[async_trait]
+    impl Tool for MockTool {
+        fn name(&self) -> &str { &self.name }
+        fn description(&self) -> &str { "Mock tool for testing" }
+        
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "input": { "type": "string", "description": "Input parameter" }
+                },
+                "required": ["input"]
+            })
+        }
+        
+        async fn execute(&self, params: ToolParams) -> Result<ToolResult, PatinoxError> {
+            let input = params.parameters.get("input");
+            if input.is_none() {
+                return Ok(ToolResult {
+                    call_id: params.call_id,
+                    success: false,
+                    data: serde_json::json!({}),
+                    error: Some("Missing required parameter: input".to_string()),
+                    metadata: HashMap::new(),
+                });
+            }
+            Ok(ToolResult {
+                call_id: params.call_id,
+                success: true,
+                data: serde_json::json!({"output": format!("Mock processed: {}", input.unwrap())}),
+                error: None,
+                metadata: HashMap::new(),
+            })
+        }
+        
+        fn metadata(&self) -> ToolMetadata {
+            ToolMetadata {
+                category: "mock".to_string(),
+                tags: vec!["testing".to_string()],
+                version: "1.0.0".to_string(),
+                author: Some("Test Suite".to_string()),
+                dangerous: false,
+            }
+        }
+    }
+
+    pub struct MockValidator {
+        name: String,
+        config: ValidatorConfig,
+    }
+
+    impl MockValidator {
+        pub fn new(name: &str) -> Self {
+            Self {
+                name: name.to_string(),
+                config: ValidatorConfig {
+                    name: name.to_string(),
+                    enabled: true,
+                    priority: 0,
+                    stages: vec![ValidationStage::PreExecution, ValidationStage::PreResponse],
+                    parameters: HashMap::new(),
+                },
+            }
+        }
+    }
+
+
+    #[async_trait]
+    impl Validator for MockValidator {
+        fn name(&self) -> &str { &self.name }
+        fn config(&self) -> &ValidatorConfig { &self.config }
+        
+        fn should_validate(&self, request: &ValidationRequest) -> bool {
+            self.config.stages.contains(&request.stage)
+        }
+
+        async fn validate(&self, request: ValidationRequest) -> Result<ValidationResponse, PatinoxError> {
+            match &request.content {
+                ValidationContent::UserMessage { message } => {
+                    if message.contains("unsafe") {
+                        Ok(ValidationResponse {
+                            approved: false,
+                            reason: Some("Unsafe content detected".to_string()),
+                            modifications: None,
+                            metadata: HashMap::new(),
+                        })
+                    } else {
+                        Ok(ValidationResponse {
+                            approved: true,
+                            reason: None,
+                            modifications: None,
+                            metadata: HashMap::new(),
+                        })
+                    }
+                },
+                _ => Ok(ValidationResponse {
+                    approved: true,
+                    reason: None,
+                    modifications: None,
+                    metadata: HashMap::new(),
+                })
+            }
+        }
+    }
+
+    pub struct MockMonitor {
+        name: String,
+        config: MonitorConfig,
+        events: std::sync::Arc<std::sync::Mutex<Vec<MonitorEvent>>>,
+    }
+
+    impl MockMonitor {
+        pub fn new(name: &str) -> Self {
+            Self {
+                name: name.to_string(),
+                config: MonitorConfig {
+                    name: name.to_string(),
+                    enabled: true,
+                    buffer_size: 1000,
+                    flush_interval_ms: 5000,
+                    sampling_rate: 1.0,
+                    event_types: vec![MonitorEventType::ExecutionStarted],
+                },
+                events: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Monitor for MockMonitor {
+        fn name(&self) -> &str { &self.name }
+
+        async fn start_monitoring(&self, execution_id: Uuid, agent_id: Uuid) -> Result<(), PatinoxError> {
+            let event = MonitorEvent {
+                id: Uuid::new_v4(),
+                execution_id,
+                agent_id,
+                timestamp: chrono::Utc::now(),
+                event_type: MonitorEventType::ExecutionStarted,
+                data: serde_json::json!({}),
+                metadata: HashMap::new(),
+            };
+            self.events.lock().map_err(|_| {
+                PatinoxError::Execution(crate::error::ExecutionError::ResourceExhausted(
+                    "Monitor event storage corrupted".to_string()
+                ))
+            })?.push(event);
+            Ok(())
+        }
+
+        async fn record_event(&self, event: MonitorEvent) -> Result<(), PatinoxError> {
+            self.events.lock().map_err(|_| {
+                PatinoxError::Execution(crate::error::ExecutionError::ResourceExhausted(
+                    "Monitor event storage corrupted".to_string()
+                ))
+            })?.push(event);
+            Ok(())
+        }
+
+        async fn complete_monitoring(&self, execution_id: Uuid, summary: ExecutionSummary) -> Result<(), PatinoxError> {
+            let event = MonitorEvent {
+                id: Uuid::new_v4(),
+                execution_id,
+                agent_id: summary.agent_id,
+                timestamp: chrono::Utc::now(),
+                event_type: MonitorEventType::ExecutionCompleted {
+                    success: summary.success,
+                    total_duration_ms: summary.total_duration_ms,
+                },
+                data: serde_json::to_value(&summary).unwrap(),
+                metadata: HashMap::new(),
+            };
+            self.events.lock().map_err(|_| {
+                PatinoxError::Execution(crate::error::ExecutionError::ResourceExhausted(
+                    "Monitor event storage corrupted".to_string()
+                ))
+            })?.push(event);
+            Ok(())
+        }
+
+        async fn query_events(&self, _query: MonitorQuery) -> Result<Vec<MonitorEvent>, PatinoxError> {
+            Ok(self.events.lock().map_err(|_| {
+                PatinoxError::Execution(crate::error::ExecutionError::ResourceExhausted(
+                    "Monitor event storage corrupted".to_string()
+                ))
+            })?.clone())
+        }
+
+        fn config(&self) -> &MonitorConfig { &self.config }
+    }
+}
+
+// Module structure - traits will be implemented in separate files
+pub mod agent;
+pub mod tool;
+pub mod validator;
+pub mod monitor;
+
+// Re-export core traits for convenience
+pub use agent::{Agent, AgentState, AgentConfig, AgentRequest, AgentResponse, HealthStatus, AgentBuilder};
+pub use tool::{Tool, ToolCall, ToolParams, ToolResult, ToolMetadata};
+pub use validator::{Validator, ValidationRequest, ValidationResponse, ValidationStage, ValidationContent, ValidatorConfig, ValidationModifications};
+pub use monitor::{Monitor, MonitorEvent, MonitorEventType, ExecutionSummary, MonitorQuery, MonitorConfig};
+
+// Supporting types used across traits
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Usage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+    pub cost_usd: Option<f64>,
+}

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -991,10 +991,20 @@ pub use validator::{
 // Supporting types used across traits
 use serde::{Deserialize, Serialize};
 
+/// Token usage and cost tracking for LLM operations
+///
+/// This struct captures the essential metrics for understanding and optimizing
+/// LLM usage across the Patinox framework. All agents and tools should report
+/// usage information to enable cost monitoring and performance analysis.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Usage {
+    /// Number of tokens in the input prompt
     pub prompt_tokens: u32,
+    /// Number of tokens generated in the response  
     pub completion_tokens: u32,
+    /// Total tokens used (prompt + completion)
     pub total_tokens: u32,
+    /// Estimated cost in USD, if available from provider
+    /// Note: Cost calculation depends on provider pricing models
     pub cost_usd: Option<f64>,
 }

--- a/src/traits/monitor.rs
+++ b/src/traits/monitor.rs
@@ -1,0 +1,650 @@
+//! Monitor trait definition and supporting types
+//!
+//! This module defines the core Monitor trait for asynchronous monitoring
+//! of agent behavior and performance. Monitors collect telemetry data
+//! for analysis and improvement of agent systems.
+
+use crate::error::PatinoxError;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+// Tests written FIRST to define the contract
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Mock implementation for testing
+    struct TestMonitor {
+        name: String,
+        config: MonitorConfig,
+        events: std::sync::Arc<std::sync::Mutex<Vec<MonitorEvent>>>,
+    }
+
+    #[async_trait]
+    impl Monitor for TestMonitor {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        async fn start_monitoring(&self, execution_id: Uuid, agent_id: Uuid) -> Result<(), PatinoxError> {
+            // Start monitoring by recording a start event
+            let event = MonitorEvent {
+                id: Uuid::new_v4(),
+                execution_id,
+                agent_id,
+                timestamp: chrono::Utc::now(),
+                event_type: MonitorEventType::ExecutionStarted,
+                data: serde_json::json!({}),
+                metadata: HashMap::new(),
+            };
+            
+            let mut events = self.events.lock().map_err(|_| {
+                PatinoxError::Execution(crate::error::ExecutionError::ResourceExhausted(
+                    "Monitor event storage corrupted".to_string()
+                ))
+            })?;
+            events.push(event);
+            Ok(())
+        }
+
+        async fn record_event(&self, event: MonitorEvent) -> Result<(), PatinoxError> {
+            let mut events = self.events.lock().map_err(|_| {
+                PatinoxError::Execution(crate::error::ExecutionError::ResourceExhausted(
+                    "Monitor event storage corrupted".to_string()
+                ))
+            })?;
+            events.push(event);
+            Ok(())
+        }
+
+        async fn complete_monitoring(&self, execution_id: Uuid, summary: ExecutionSummary) -> Result<(), PatinoxError> {
+            let event = MonitorEvent {
+                id: Uuid::new_v4(),
+                execution_id,
+                agent_id: summary.agent_id,
+                timestamp: chrono::Utc::now(),
+                event_type: MonitorEventType::ExecutionCompleted {
+                    success: summary.success,
+                    total_duration_ms: summary.total_duration_ms,
+                },
+                data: serde_json::to_value(&summary).unwrap(),
+                metadata: HashMap::new(),
+            };
+            
+            let mut events = self.events.lock().map_err(|_| {
+                PatinoxError::Execution(crate::error::ExecutionError::ResourceExhausted(
+                    "Monitor event storage corrupted".to_string()
+                ))
+            })?;
+            events.push(event);
+            Ok(())
+        }
+
+        async fn query_events(&self, query: MonitorQuery) -> Result<Vec<MonitorEvent>, PatinoxError> {
+            let events = self.events.lock().map_err(|_| {
+                PatinoxError::Execution(crate::error::ExecutionError::ResourceExhausted(
+                    "Monitor event storage corrupted".to_string()
+                ))
+            })?;
+            let mut filtered_events = Vec::new();
+
+            for event in events.iter() {
+                let mut matches = true;
+
+                // Filter by agent IDs
+                if let Some(ref agent_ids) = query.agent_ids {
+                    if !agent_ids.contains(&event.agent_id) {
+                        matches = false;
+                    }
+                }
+
+                // Filter by event types
+                if let Some(ref event_types) = query.event_types {
+                    if !event_types.iter().any(|et| std::mem::discriminant(et) == std::mem::discriminant(&event.event_type)) {
+                        matches = false;
+                    }
+                }
+
+                // Filter by time range
+                if let Some(start_time) = query.start_time {
+                    if event.timestamp < start_time {
+                        matches = false;
+                    }
+                }
+
+                if let Some(end_time) = query.end_time {
+                    if event.timestamp > end_time {
+                        matches = false;
+                    }
+                }
+
+                if matches {
+                    filtered_events.push(event.clone());
+                }
+
+                // Apply limit
+                if let Some(limit) = query.limit {
+                    if filtered_events.len() >= limit as usize {
+                        break;
+                    }
+                }
+            }
+
+            Ok(filtered_events)
+        }
+
+        fn config(&self) -> &MonitorConfig {
+            &self.config
+        }
+    }
+
+    impl TestMonitor {
+        fn new(name: &str) -> Self {
+            Self {
+                name: name.to_string(),
+                config: MonitorConfig {
+                    name: name.to_string(),
+                    enabled: true,
+                    buffer_size: 1000,
+                    flush_interval_ms: 5000,
+                    sampling_rate: 1.0,
+                    event_types: vec![
+                        MonitorEventType::ExecutionStarted,
+                        MonitorEventType::ExecutionCompleted { success: true, total_duration_ms: 0 },
+                    ],
+                },
+                events: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            }
+        }
+
+        fn event_count(&self) -> usize {
+            self.events.lock().map(|events| events.len()).unwrap_or(0)
+        }
+    }
+
+    #[test]
+    fn monitor_event_serialization() {
+        let event = MonitorEvent {
+            id: Uuid::new_v4(),
+            execution_id: Uuid::new_v4(),
+            agent_id: Uuid::new_v4(),
+            timestamp: chrono::Utc::now(),
+            event_type: MonitorEventType::LlmCalled {
+                provider: "openai".to_string(),
+                model: "gpt-4".to_string(),
+                tokens: crate::traits::Usage {
+                    prompt_tokens: 100,
+                    completion_tokens: 50,
+                    total_tokens: 150,
+                    cost_usd: Some(0.003),
+                },
+            },
+            data: serde_json::json!({"additional": "data"}),
+            metadata: {
+                let mut meta = HashMap::new();
+                meta.insert("request_id".to_string(), "req-123".to_string());
+                meta
+            },
+        };
+
+        let serialized = serde_json::to_string(&event).expect("Should serialize");
+        let deserialized: MonitorEvent = serde_json::from_str(&serialized).expect("Should deserialize");
+
+        assert_eq!(deserialized.id, event.id);
+        assert_eq!(deserialized.execution_id, event.execution_id);
+        assert_eq!(deserialized.agent_id, event.agent_id);
+        assert_eq!(deserialized.data["additional"], "data");
+        assert_eq!(deserialized.metadata["request_id"], "req-123");
+
+        // Test event type specifics
+        match deserialized.event_type {
+            MonitorEventType::LlmCalled { provider, model, tokens } => {
+                assert_eq!(provider, "openai");
+                assert_eq!(model, "gpt-4");
+                assert_eq!(tokens.total_tokens, 150);
+            },
+            _ => panic!("Expected LlmCalled event type"),
+        }
+    }
+
+    #[test]
+    fn monitor_event_type_variants() {
+        let event_types = vec![
+            MonitorEventType::ExecutionStarted,
+            MonitorEventType::ValidationPassed { validator: "test".to_string() },
+            MonitorEventType::ValidationFailed { validator: "test".to_string(), reason: "failed".to_string() },
+            MonitorEventType::ToolExecuted { tool: "calc".to_string(), duration_ms: 150 },
+            MonitorEventType::LlmCalled {
+                provider: "openai".to_string(),
+                model: "gpt-4".to_string(),
+                tokens: crate::traits::Usage {
+                    prompt_tokens: 10,
+                    completion_tokens: 5,
+                    total_tokens: 15,
+                    cost_usd: None,
+                },
+            },
+            MonitorEventType::ErrorOccurred { error_type: "timeout".to_string(), recoverable: true },
+            MonitorEventType::ExecutionCompleted { success: true, total_duration_ms: 2500 },
+        ];
+
+        for event_type in event_types {
+            // All variants should be debuggable, cloneable, and serializable
+            let _debug = format!("{:?}", event_type);
+            let _cloned = event_type.clone();
+            let _serialized = serde_json::to_string(&event_type).expect("Should serialize");
+        }
+    }
+
+    #[test]
+    fn execution_summary_serialization() {
+        let summary = ExecutionSummary {
+            execution_id: Uuid::new_v4(),
+            agent_id: Uuid::new_v4(),
+            success: true,
+            total_duration_ms: 5000,
+            llm_calls: 3,
+            tool_calls: 5,
+            validation_failures: 1,
+            total_tokens: crate::traits::Usage {
+                prompt_tokens: 300,
+                completion_tokens: 150,
+                total_tokens: 450,
+                cost_usd: Some(0.009),
+            },
+            error_summary: Some("Minor validation warning".to_string()),
+        };
+
+        let serialized = serde_json::to_string(&summary).expect("Should serialize");
+        let deserialized: ExecutionSummary = serde_json::from_str(&serialized).expect("Should deserialize");
+
+        assert_eq!(deserialized.execution_id, summary.execution_id);
+        assert_eq!(deserialized.agent_id, summary.agent_id);
+        assert_eq!(deserialized.success, summary.success);
+        assert_eq!(deserialized.total_duration_ms, summary.total_duration_ms);
+        assert_eq!(deserialized.llm_calls, summary.llm_calls);
+        assert_eq!(deserialized.tool_calls, summary.tool_calls);
+        assert_eq!(deserialized.validation_failures, summary.validation_failures);
+        assert_eq!(deserialized.total_tokens.total_tokens, summary.total_tokens.total_tokens);
+        assert_eq!(deserialized.error_summary, summary.error_summary);
+    }
+
+    #[test]
+    fn monitor_query_structure() {
+        let query = MonitorQuery {
+            agent_ids: Some(vec![Uuid::new_v4(), Uuid::new_v4()]),
+            event_types: Some(vec![
+                MonitorEventType::ExecutionStarted,
+                MonitorEventType::ExecutionCompleted { success: true, total_duration_ms: 0 },
+            ]),
+            start_time: Some(chrono::Utc::now() - chrono::Duration::hours(1)),
+            end_time: Some(chrono::Utc::now()),
+            limit: Some(100),
+        };
+
+        // Should be debuggable and cloneable
+        let _debug = format!("{:?}", query);
+        let cloned = query.clone();
+        assert_eq!(cloned.agent_ids.as_ref().expect("Should have agent IDs").len(), 2);
+        assert_eq!(cloned.event_types.as_ref().expect("Should have event types").len(), 2);
+        assert_eq!(cloned.limit, Some(100));
+    }
+
+    #[test]
+    fn monitor_config_serialization() {
+        let config = MonitorConfig {
+            name: "test-monitor".to_string(),
+            enabled: true,
+            buffer_size: 5000,
+            flush_interval_ms: 10000,
+            sampling_rate: 0.8,
+            event_types: vec![
+                MonitorEventType::ExecutionStarted,
+                MonitorEventType::ValidationFailed { validator: "test".to_string(), reason: "test".to_string() },
+            ],
+        };
+
+        let serialized = serde_json::to_string(&config).expect("Should serialize");
+        let deserialized: MonitorConfig = serde_json::from_str(&serialized).expect("Should deserialize");
+
+        assert_eq!(deserialized.name, config.name);
+        assert_eq!(deserialized.enabled, config.enabled);
+        assert_eq!(deserialized.buffer_size, config.buffer_size);
+        assert_eq!(deserialized.flush_interval_ms, config.flush_interval_ms);
+        assert_eq!(deserialized.sampling_rate, config.sampling_rate);
+        assert_eq!(deserialized.event_types.len(), config.event_types.len());
+    }
+
+    #[tokio::test]
+    async fn monitor_basic_functionality() {
+        let monitor = TestMonitor::new("test-monitor");
+
+        // Test metadata access
+        assert_eq!(monitor.name(), "test-monitor");
+        
+        let config = monitor.config();
+        assert_eq!(config.name, "test-monitor");
+        assert!(config.enabled);
+        assert!(config.buffer_size > 0);
+        assert!(config.flush_interval_ms > 0);
+        assert!(config.sampling_rate > 0.0 && config.sampling_rate <= 1.0);
+    }
+
+    #[tokio::test]
+    async fn monitor_execution_lifecycle() {
+        let monitor = TestMonitor::new("lifecycle-test");
+        let execution_id = Uuid::new_v4();
+        let agent_id = Uuid::new_v4();
+
+        assert_eq!(monitor.event_count(), 0);
+
+        // Start monitoring
+        let result = monitor.start_monitoring(execution_id, agent_id).await;
+        assert!(result.is_ok());
+        assert_eq!(monitor.event_count(), 1);
+
+        // Record some events
+        let event1 = MonitorEvent {
+            id: Uuid::new_v4(),
+            execution_id,
+            agent_id,
+            timestamp: chrono::Utc::now(),
+            event_type: MonitorEventType::ValidationPassed { validator: "test".to_string() },
+            data: serde_json::json!({}),
+            metadata: HashMap::new(),
+        };
+
+        let result = monitor.record_event(event1).await;
+        assert!(result.is_ok());
+        assert_eq!(monitor.event_count(), 2);
+
+        let event2 = MonitorEvent {
+            id: Uuid::new_v4(),
+            execution_id,
+            agent_id,
+            timestamp: chrono::Utc::now(),
+            event_type: MonitorEventType::ToolExecuted { tool: "calculator".to_string(), duration_ms: 250 },
+            data: serde_json::json!({"result": "42"}),
+            metadata: HashMap::new(),
+        };
+
+        let result = monitor.record_event(event2).await;
+        assert!(result.is_ok());
+        assert_eq!(monitor.event_count(), 3);
+
+        // Complete monitoring
+        let summary = ExecutionSummary {
+            execution_id,
+            agent_id,
+            success: true,
+            total_duration_ms: 1500,
+            llm_calls: 1,
+            tool_calls: 2,
+            validation_failures: 0,
+            total_tokens: crate::traits::Usage {
+                prompt_tokens: 100,
+                completion_tokens: 50,
+                total_tokens: 150,
+                cost_usd: Some(0.003),
+            },
+            error_summary: None,
+        };
+
+        let result = monitor.complete_monitoring(execution_id, summary).await;
+        assert!(result.is_ok());
+        assert_eq!(monitor.event_count(), 4);
+    }
+
+    #[tokio::test]
+    async fn monitor_query_functionality() {
+        let monitor = TestMonitor::new("query-test");
+        let agent1_id = Uuid::new_v4();
+        let agent2_id = Uuid::new_v4();
+        let execution1_id = Uuid::new_v4();
+        let execution2_id = Uuid::new_v4();
+
+        // Add some test events
+        let events = vec![
+            MonitorEvent {
+                id: Uuid::new_v4(),
+                execution_id: execution1_id,
+                agent_id: agent1_id,
+                timestamp: chrono::Utc::now() - chrono::Duration::minutes(10),
+                event_type: MonitorEventType::ExecutionStarted,
+                data: serde_json::json!({}),
+                metadata: HashMap::new(),
+            },
+            MonitorEvent {
+                id: Uuid::new_v4(),
+                execution_id: execution2_id,
+                agent_id: agent2_id,
+                timestamp: chrono::Utc::now() - chrono::Duration::minutes(5),
+                event_type: MonitorEventType::ValidationPassed { validator: "test".to_string() },
+                data: serde_json::json!({}),
+                metadata: HashMap::new(),
+            },
+            MonitorEvent {
+                id: Uuid::new_v4(),
+                execution_id: execution1_id,
+                agent_id: agent1_id,
+                timestamp: chrono::Utc::now(),
+                event_type: MonitorEventType::ExecutionCompleted { success: true, total_duration_ms: 600000 },
+                data: serde_json::json!({}),
+                metadata: HashMap::new(),
+            },
+        ];
+
+        for event in events {
+            monitor.record_event(event).await.unwrap();
+        }
+
+        // Query all events
+        let query = MonitorQuery {
+            agent_ids: None,
+            event_types: None,
+            start_time: None,
+            end_time: None,
+            limit: None,
+        };
+
+        let result = monitor.query_events(query).await;
+        assert!(result.is_ok());
+        assert_eq!(result.expect("All events query should succeed").len(), 3);
+
+        // Query by agent ID
+        let query = MonitorQuery {
+            agent_ids: Some(vec![agent1_id]),
+            event_types: None,
+            start_time: None,
+            end_time: None,
+            limit: None,
+        };
+
+        let result = monitor.query_events(query).await;
+        assert!(result.is_ok());
+        assert_eq!(result.expect("Agent ID query should succeed").len(), 2);
+
+        // Query by event type
+        let query = MonitorQuery {
+            agent_ids: None,
+            event_types: Some(vec![MonitorEventType::ExecutionStarted]),
+            start_time: None,
+            end_time: None,
+            limit: None,
+        };
+
+        let result = monitor.query_events(query).await;
+        assert!(result.is_ok());
+        assert_eq!(result.expect("Event type query should succeed").len(), 1);
+
+        // Query with limit
+        let query = MonitorQuery {
+            agent_ids: None,
+            event_types: None,
+            start_time: None,
+            end_time: None,
+            limit: Some(1),
+        };
+
+        let result = monitor.query_events(query).await;
+        assert!(result.is_ok());
+        assert_eq!(result.expect("Limit query should succeed").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn monitor_object_safety() {
+        // Test that we can create trait objects
+        let monitor: Box<dyn Monitor> = Box::new(TestMonitor::new("boxed-monitor"));
+
+        // Test that trait object methods work
+        let _name = monitor.name();
+        let _config = monitor.config();
+
+        let execution_id = Uuid::new_v4();
+        let agent_id = Uuid::new_v4();
+
+        // Test async methods work with trait objects
+        let _result = monitor.start_monitoring(execution_id, agent_id).await;
+
+        let event = MonitorEvent {
+            id: Uuid::new_v4(),
+            execution_id,
+            agent_id,
+            timestamp: chrono::Utc::now(),
+            event_type: MonitorEventType::ExecutionStarted,
+            data: serde_json::json!({}),
+            metadata: HashMap::new(),
+        };
+
+        let _result = monitor.record_event(event).await;
+
+        // Test that we can store multiple monitors in a collection
+        let monitors: Vec<Box<dyn Monitor>> = vec![
+            Box::new(TestMonitor::new("monitor1")),
+            Box::new(TestMonitor::new("monitor2")),
+        ];
+
+        assert_eq!(monitors.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn monitor_send_sync() {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+
+        assert_send::<Box<dyn Monitor>>();
+        assert_sync::<Box<dyn Monitor>>();
+
+        // Test that we can pass trait objects across thread boundaries
+        let monitor: Box<dyn Monitor> = Box::new(TestMonitor::new("thread-test"));
+        let monitor_name = monitor.name().to_string();
+
+        tokio::spawn(async move {
+            let _name = monitor.name();
+            // Monitor trait object can be moved across threads
+        }).await.unwrap();
+
+        assert_eq!(monitor_name, "thread-test");
+    }
+
+    #[test]
+    fn usage_type_functionality() {
+        let usage = crate::traits::Usage {
+            prompt_tokens: 150,
+            completion_tokens: 75,
+            total_tokens: 225,
+            cost_usd: Some(0.0045),
+        };
+
+        // Should be debuggable and cloneable
+        let _debug = format!("{:?}", usage);
+        let cloned = usage.clone();
+        assert_eq!(cloned.prompt_tokens, usage.prompt_tokens);
+        assert_eq!(cloned.completion_tokens, usage.completion_tokens);
+        assert_eq!(cloned.total_tokens, usage.total_tokens);
+        assert_eq!(cloned.cost_usd, usage.cost_usd);
+
+        // Should be serializable
+        let serialized = serde_json::to_string(&usage).expect("Should serialize");
+        let deserialized: crate::traits::Usage = serde_json::from_str(&serialized).expect("Should deserialize");
+        assert_eq!(deserialized.total_tokens, usage.total_tokens);
+    }
+}
+
+/// Asynchronous monitoring for agent behavior analysis
+#[async_trait]
+pub trait Monitor: Send + Sync {
+    /// Monitor identifier
+    fn name(&self) -> &str;
+    
+    /// Start monitoring an agent execution
+    async fn start_monitoring(&self, execution_id: Uuid, agent_id: Uuid) -> Result<(), PatinoxError>;
+    
+    /// Record an event during execution
+    async fn record_event(&self, event: MonitorEvent) -> Result<(), PatinoxError>;
+    
+    /// Complete monitoring for an execution
+    async fn complete_monitoring(&self, execution_id: Uuid, summary: ExecutionSummary) -> Result<(), PatinoxError>;
+    
+    /// Query monitoring data for analysis
+    async fn query_events(&self, query: MonitorQuery) -> Result<Vec<MonitorEvent>, PatinoxError>;
+    
+    /// Get monitoring configuration
+    fn config(&self) -> &MonitorConfig;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MonitorEvent {
+    pub id: Uuid,
+    pub execution_id: Uuid,
+    pub agent_id: Uuid,
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+    pub event_type: MonitorEventType,
+    pub data: serde_json::Value,
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MonitorEventType {
+    ExecutionStarted,
+    ValidationPassed { validator: String },
+    ValidationFailed { validator: String, reason: String },
+    ToolExecuted { tool: String, duration_ms: u64 },
+    LlmCalled { provider: String, model: String, tokens: crate::traits::Usage },
+    ErrorOccurred { error_type: String, recoverable: bool },
+    ExecutionCompleted { success: bool, total_duration_ms: u64 },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionSummary {
+    pub execution_id: Uuid,
+    pub agent_id: Uuid,
+    pub success: bool,
+    pub total_duration_ms: u64,
+    pub llm_calls: u32,
+    pub tool_calls: u32,
+    pub validation_failures: u32,
+    pub total_tokens: crate::traits::Usage,
+    pub error_summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MonitorQuery {
+    pub agent_ids: Option<Vec<Uuid>>,
+    pub event_types: Option<Vec<MonitorEventType>>,
+    pub start_time: Option<chrono::DateTime<chrono::Utc>>,
+    pub end_time: Option<chrono::DateTime<chrono::Utc>>,
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MonitorConfig {
+    pub name: String,
+    pub enabled: bool,
+    pub buffer_size: u32,
+    pub flush_interval_ms: u64,
+    pub sampling_rate: f64, // 0.0 to 1.0
+    pub event_types: Vec<MonitorEventType>,
+}

--- a/src/traits/tool.rs
+++ b/src/traits/tool.rs
@@ -1,0 +1,399 @@
+//! Tool trait definition and supporting types
+//!
+//! This module defines the core Tool trait that all tool implementations
+//! must implement. Tools are executable functions that agents can call
+//! to perform specific actions or retrieve information.
+
+use crate::error::PatinoxError;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// Tests written FIRST to define the contract
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Mock implementation for testing
+    struct TestTool {
+        name: String,
+    }
+
+    #[async_trait]
+    impl Tool for TestTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn description(&self) -> &str {
+            "A test tool for validation"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "input": {
+                        "type": "string",
+                        "description": "Input parameter"
+                    }
+                },
+                "required": ["input"]
+            })
+        }
+
+        async fn execute(&self, params: ToolParams) -> Result<ToolResult, PatinoxError> {
+            // Validate parameters
+            let input = params.parameters.get("input");
+            if input.is_none() {
+                return Ok(ToolResult {
+                    call_id: params.call_id,
+                    success: false,
+                    data: serde_json::json!({}),
+                    error: Some("Missing required parameter: input".to_string()),
+                    metadata: HashMap::new(),
+                });
+            }
+
+            // Return success result
+            Ok(ToolResult {
+                call_id: params.call_id,
+                success: true,
+                data: serde_json::json!({
+                    "output": format!("Processed: {}", input.unwrap())
+                }),
+                error: None,
+                metadata: HashMap::new(),
+            })
+        }
+
+        fn metadata(&self) -> ToolMetadata {
+            ToolMetadata {
+                category: "test".to_string(),
+                tags: vec!["testing".to_string(), "validation".to_string()],
+                version: "1.0.0".to_string(),
+                author: Some("Test Suite".to_string()),
+                dangerous: false,
+            }
+        }
+    }
+
+    impl TestTool {
+        fn new(name: &str) -> Self {
+            Self {
+                name: name.to_string(),
+            }
+        }
+    }
+
+    #[test]
+    fn tool_call_serialization() {
+        let tool_call = ToolCall {
+            id: "call-123".to_string(),
+            name: "test-tool".to_string(),
+            parameters: serde_json::json!({"input": "test value"}),
+        };
+
+        let serialized = serde_json::to_string(&tool_call).expect("Should serialize");
+        let deserialized: ToolCall = serde_json::from_str(&serialized).expect("Should deserialize");
+
+        assert_eq!(deserialized.id, tool_call.id);
+        assert_eq!(deserialized.name, tool_call.name);
+        assert_eq!(deserialized.parameters["input"], "test value");
+    }
+
+    #[test]
+    fn tool_params_structure() {
+        let params = ToolParams {
+            call_id: "call-456".to_string(),
+            parameters: serde_json::json!({"key": "value"}),
+            context: {
+                let mut ctx = HashMap::new();
+                ctx.insert("session".to_string(), serde_json::json!("session123"));
+                ctx
+            },
+        };
+
+        assert_eq!(params.call_id, "call-456");
+        assert_eq!(params.parameters["key"], "value");
+        assert_eq!(params.context["session"], "session123");
+    }
+
+    #[test]
+    fn tool_result_serialization() {
+        let result = ToolResult {
+            call_id: "call-789".to_string(),
+            success: true,
+            data: serde_json::json!({"result": "success"}),
+            error: None,
+            metadata: {
+                let mut meta = HashMap::new();
+                meta.insert("duration_ms".to_string(), "150".to_string());
+                meta
+            },
+        };
+
+        let serialized = serde_json::to_string(&result).expect("Should serialize");
+        let deserialized: ToolResult = serde_json::from_str(&serialized).expect("Should deserialize");
+
+        assert_eq!(deserialized.call_id, result.call_id);
+        assert_eq!(deserialized.success, result.success);
+        assert_eq!(deserialized.data["result"], "success");
+        assert_eq!(deserialized.error, None);
+        assert_eq!(deserialized.metadata["duration_ms"], "150");
+    }
+
+    #[test]
+    fn tool_result_with_error() {
+        let result = ToolResult {
+            call_id: "call-error".to_string(),
+            success: false,
+            data: serde_json::json!({}),
+            error: Some("Parameter validation failed".to_string()),
+            metadata: HashMap::new(),
+        };
+
+        assert!(!result.success);
+        assert!(result.error.is_some());
+        assert_eq!(result.error.expect("Should have error message"), "Parameter validation failed");
+    }
+
+    #[test]
+    fn tool_metadata_completeness() {
+        let metadata = ToolMetadata {
+            category: "data".to_string(),
+            tags: vec!["database".to_string(), "query".to_string()],
+            version: "2.1.0".to_string(),
+            author: Some("DataTeam".to_string()),
+            dangerous: true,
+        };
+
+        assert_eq!(metadata.category, "data");
+        assert_eq!(metadata.tags.len(), 2);
+        assert!(metadata.tags.contains(&"database".to_string()));
+        assert!(metadata.tags.contains(&"query".to_string()));
+        assert_eq!(metadata.version, "2.1.0");
+        assert_eq!(metadata.author, Some("DataTeam".to_string()));
+        assert!(metadata.dangerous);
+    }
+
+    #[tokio::test]
+    async fn tool_basic_functionality() {
+        let tool = TestTool::new("test-tool");
+
+        // Test metadata access
+        assert_eq!(tool.name(), "test-tool");
+        assert!(!tool.description().is_empty());
+
+        let schema = tool.parameters_schema();
+        assert!(schema.is_object());
+        assert!(schema["properties"].is_object());
+
+        let metadata = tool.metadata();
+        assert_eq!(metadata.category, "test");
+        assert!(!metadata.version.is_empty());
+    }
+
+    #[tokio::test]
+    async fn tool_successful_execution() {
+        let tool = TestTool::new("test-tool");
+
+        let params = ToolParams {
+            call_id: "success-test".to_string(),
+            parameters: serde_json::json!({"input": "Hello World"}),
+            context: HashMap::new(),
+        };
+
+        let result = tool.execute(params).await.expect("Execution should succeed");
+
+        // Test tool contract requirements
+        assert_eq!(result.call_id, "success-test", "Call ID should be preserved");
+        assert!(result.success, "Valid input should result in successful execution");
+        assert!(result.error.is_none(), "Successful execution should not have errors");
+        
+        // Test that tool actually processes the input (not just returns it)
+        if let Some(output) = result.data["output"].as_str() {
+            assert!(output.contains("Processed:"), "Tool should process input, not just return it");
+            assert!(output.contains("Hello World"), "Tool should include original input in processed output");
+            assert!(output.len() > "Hello World".len(), "Processed output should be longer than raw input");
+        } else {
+            panic!("Tool should return structured output data");
+        }
+        
+        // Test metadata is properly initialized
+        assert!(result.metadata.is_empty() || !result.metadata.is_empty(), "Metadata should be initialized");
+    }
+
+    #[tokio::test]
+    async fn tool_parameter_validation() {
+        let tool = TestTool::new("test-tool");
+
+        // Test missing required parameter
+        let missing_params = ToolParams {
+            call_id: "validation-test".to_string(),
+            parameters: serde_json::json!({"wrong": "parameter"}),
+            context: HashMap::new(),
+        };
+
+        let result = tool.execute(missing_params).await.expect("Execution should complete");
+
+        // Test proper error handling for validation failures
+        assert_eq!(result.call_id, "validation-test", "Call ID should be preserved in errors");
+        assert!(!result.success, "Invalid parameters should result in failure");
+        assert!(result.error.is_some(), "Validation failures should include error message");
+        assert_eq!(result.data, serde_json::json!({}), "Failed executions should return empty data");
+        
+        if let Some(error) = result.error {
+            assert!(error.contains("Missing required parameter"), "Error should be descriptive");
+            assert!(error.contains("input"), "Error should mention the missing parameter name");
+        } else {
+            panic!("Validation failure should include specific error message");
+        }
+        
+        // Test with empty parameters object
+        let empty_params = ToolParams {
+            call_id: "empty-test".to_string(),
+            parameters: serde_json::json!({}),
+            context: HashMap::new(),
+        };
+        
+        let empty_result = tool.execute(empty_params).await.expect("Should handle empty params");
+        assert!(!empty_result.success, "Empty parameters should fail validation");
+        assert!(empty_result.error.is_some(), "Should provide error for empty parameters");
+        
+        // Test with null parameter value
+        let null_params = ToolParams {
+            call_id: "null-test".to_string(),
+            parameters: serde_json::json!({"input": null}),
+            context: HashMap::new(),
+        };
+        
+        let null_result = tool.execute(null_params).await.expect("Should handle null values");
+        // Behavior depends on implementation - either fail validation or handle gracefully
+        if !null_result.success {
+            assert!(null_result.error.is_some(), "Null parameter failure should include error");
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_object_safety() {
+        // Test that we can create trait objects
+        let tool: Box<dyn Tool> = Box::new(TestTool::new("boxed-tool"));
+
+        // Test that trait object methods work
+        let _name = tool.name();
+        let _description = tool.description();
+        let _schema = tool.parameters_schema();
+        let _metadata = tool.metadata();
+
+        // Test async method works with trait objects
+        let params = ToolParams {
+            call_id: "object-test".to_string(),
+            parameters: serde_json::json!({"input": "test"}),
+            context: HashMap::new(),
+        };
+
+        let _result = tool.execute(params).await;
+
+        // Test that we can store multiple tools in a collection
+        let tools: Vec<Box<dyn Tool>> = vec![
+            Box::new(TestTool::new("tool1")),
+            Box::new(TestTool::new("tool2")),
+        ];
+
+        assert_eq!(tools.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn tool_send_sync() {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+
+        assert_send::<Box<dyn Tool>>();
+        assert_sync::<Box<dyn Tool>>();
+
+        // Test that we can pass trait objects across thread boundaries
+        let tool: Box<dyn Tool> = Box::new(TestTool::new("thread-test"));
+        let tool_name = tool.name().to_string();
+
+        tokio::spawn(async move {
+            let _name = tool.name();
+            // Tool trait object can be moved across threads
+        }).await.unwrap();
+
+        assert_eq!(tool_name, "thread-test");
+    }
+
+    #[test]
+    fn tool_schema_validation() {
+        let tool = TestTool::new("schema-test");
+        let schema = tool.parameters_schema();
+
+        // Schema should be a valid JSON Schema object
+        assert!(schema.is_object());
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"].is_object());
+        assert!(schema["required"].is_array());
+
+        // Should have the expected properties
+        let properties = &schema["properties"];
+        assert!(properties["input"].is_object());
+        assert_eq!(properties["input"]["type"], "string");
+        assert!(properties["input"]["description"].is_string());
+
+        // Should specify required fields
+        let required = schema["required"].as_array().expect("Schema should have required array");
+        assert!(required.contains(&serde_json::json!("input")));
+    }
+}
+
+/// Core tool abstraction for agent actions
+#[async_trait]
+pub trait Tool: Send + Sync {
+    /// Tool identifier
+    fn name(&self) -> &str;
+    
+    /// Tool description for LLM function calling
+    fn description(&self) -> &str;
+    
+    /// JSON schema for tool parameters
+    fn parameters_schema(&self) -> serde_json::Value;
+    
+    /// Execute the tool with given parameters
+    async fn execute(&self, params: ToolParams) -> Result<ToolResult, PatinoxError>;
+    
+    /// Tool metadata for discovery and categorization
+    fn metadata(&self) -> ToolMetadata;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    pub name: String,
+    pub parameters: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolParams {
+    pub call_id: String,
+    pub parameters: serde_json::Value,
+    pub context: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolResult {
+    pub call_id: String,
+    pub success: bool,
+    pub data: serde_json::Value,
+    pub error: Option<String>,
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolMetadata {
+    pub category: String,
+    pub tags: Vec<String>,
+    pub version: String,
+    pub author: Option<String>,
+    pub dangerous: bool, // Requires extra validation
+}

--- a/src/traits/tool.rs
+++ b/src/traits/tool.rs
@@ -458,11 +458,22 @@ pub struct ToolResult {
     pub metadata: HashMap<String, String>,
 }
 
+/// Metadata for tool discovery, categorization, and security assessment
+///
+/// This metadata enables the framework to organize tools, make informed
+/// security decisions, and provide clear attribution and versioning.
 #[derive(Debug, Clone)]
 pub struct ToolMetadata {
+    /// Tool category for organization (e.g., "data", "communication", "analysis")
     pub category: String,
+    /// Tags for enhanced discoverability and filtering
     pub tags: Vec<String>,
+    /// Semantic version string for compatibility tracking
     pub version: String,
+    /// Tool author/maintainer for attribution and support
     pub author: Option<String>,
-    pub dangerous: bool, // Requires extra validation
+    /// Security flag indicating tools that require additional validation
+    /// Dangerous tools may modify system state, access external services,
+    /// or perform operations that need extra approval
+    pub dangerous: bool,
 }

--- a/src/traits/validator.rs
+++ b/src/traits/validator.rs
@@ -1,0 +1,496 @@
+//! Validator trait definition and supporting types
+//!
+//! This module defines the core Validator trait that implements the Tower Service
+//! pattern for composable validation middleware. Validators check agent requests
+//! and responses at various stages of execution.
+
+use crate::error::PatinoxError;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+// Tests written FIRST to define the contract
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Mock implementation for testing
+    struct TestValidator {
+        name: String,
+        config: ValidatorConfig,
+    }
+
+
+    #[async_trait]
+    impl Validator for TestValidator {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn config(&self) -> &ValidatorConfig {
+            &self.config
+        }
+
+        fn should_validate(&self, request: &ValidationRequest) -> bool {
+            self.config.stages.contains(&request.stage)
+        }
+
+        async fn validate(&self, request: ValidationRequest) -> Result<ValidationResponse, PatinoxError> {
+            // Simple validation logic for testing
+            match &request.content {
+                ValidationContent::UserMessage { message } => {
+                    if message.contains("unsafe") {
+                        Ok(ValidationResponse {
+                            approved: false,
+                            reason: Some("Unsafe content detected".to_string()),
+                            modifications: None,
+                            metadata: HashMap::new(),
+                        })
+                    } else {
+                        Ok(ValidationResponse {
+                            approved: true,
+                            reason: None,
+                            modifications: None,
+                            metadata: HashMap::new(),
+                        })
+                    }
+                },
+                _ => Ok(ValidationResponse {
+                    approved: true,
+                    reason: None,
+                    modifications: None,
+                    metadata: HashMap::new(),
+                })
+            }
+        }
+    }
+
+    impl TestValidator {
+        fn new(name: &str) -> Self {
+            Self {
+                name: name.to_string(),
+                config: ValidatorConfig {
+                    name: name.to_string(),
+                    enabled: true,
+                    priority: 0,
+                    stages: vec![ValidationStage::PreExecution, ValidationStage::PreResponse],
+                    parameters: HashMap::new(),
+                },
+            }
+        }
+    }
+
+    #[test]
+    fn validation_stage_enum_completeness() {
+        let stages = vec![
+            ValidationStage::PreExecution,
+            ValidationStage::PostExecution,
+            ValidationStage::PostTool,
+            ValidationStage::PreResponse,
+        ];
+
+        for stage in stages {
+            // Should be cloneable
+            let _cloned = stage.clone();
+            // Should be debuggable
+            let _debug = format!("{:?}", stage);
+        }
+    }
+
+    #[test]
+    fn validation_content_variants() {
+        let user_message = ValidationContent::UserMessage {
+            message: "Hello".to_string(),
+        };
+
+        let llm_response = ValidationContent::LlmResponse {
+            message: "Response".to_string(),
+            tool_calls: vec![],
+        };
+
+        let tool_result = ValidationContent::ToolResult {
+            tool_name: "test-tool".to_string(),
+            result: crate::traits::tool::ToolResult {
+                call_id: "call-1".to_string(),
+                success: true,
+                data: serde_json::json!({}),
+                error: None,
+                metadata: HashMap::new(),
+            },
+        };
+
+        let final_response = ValidationContent::FinalResponse {
+            message: "Final".to_string(),
+        };
+
+        // All variants should be cloneable and debuggable
+        let _user_clone = user_message.clone();
+        let _llm_clone = llm_response.clone();
+        let _tool_clone = tool_result.clone();
+        let _final_clone = final_response.clone();
+
+        assert!(!format!("{:?}", user_message).is_empty());
+        assert!(!format!("{:?}", llm_response).is_empty());
+        assert!(!format!("{:?}", tool_result).is_empty());
+        assert!(!format!("{:?}", final_response).is_empty());
+    }
+
+    #[test]
+    fn validation_request_structure() {
+        let request = ValidationRequest {
+            agent_id: Uuid::new_v4(),
+            request_id: Uuid::new_v4(),
+            stage: ValidationStage::PreExecution,
+            content: ValidationContent::UserMessage {
+                message: "Test message".to_string(),
+            },
+            context: {
+                let mut ctx = HashMap::new();
+                ctx.insert("session".to_string(), serde_json::json!("session123"));
+                ctx
+            },
+        };
+
+        // Should be cloneable
+        let _cloned = request.clone();
+        // Should be debuggable
+        assert!(!format!("{:?}", request).is_empty());
+        // Should have proper field access
+        assert_eq!(request.stage, ValidationStage::PreExecution);
+        assert_eq!(request.context["session"], "session123");
+    }
+
+    #[test]
+    fn validation_response_structure() {
+        let response = ValidationResponse {
+            approved: true,
+            reason: Some("Validation passed".to_string()),
+            modifications: Some(ValidationModifications {
+                modified_content: "Modified content".to_string(),
+                blocked_tool_calls: vec!["dangerous-tool".to_string()],
+                added_warnings: vec!["Warning message".to_string()],
+            }),
+            metadata: {
+                let mut meta = HashMap::new();
+                meta.insert("validator".to_string(), "test-validator".to_string());
+                meta
+            },
+        };
+
+        // Should be cloneable
+        let _cloned = response.clone();
+        // Should be debuggable
+        assert!(!format!("{:?}", response).is_empty());
+        
+        // Test field access
+        assert!(response.approved);
+        assert!(response.reason.is_some());
+        assert!(response.modifications.is_some());
+        
+        let modifications = response.modifications.expect("Should have modifications");
+        assert_eq!(modifications.modified_content, "Modified content");
+        assert!(modifications.blocked_tool_calls.contains(&"dangerous-tool".to_string()));
+        assert!(modifications.added_warnings.contains(&"Warning message".to_string()));
+    }
+
+    #[test]
+    fn validator_config_serialization() {
+        let config = ValidatorConfig {
+            name: "test-validator".to_string(),
+            enabled: true,
+            priority: 5,
+            stages: vec![ValidationStage::PreExecution, ValidationStage::PostTool],
+            parameters: {
+                let mut params = HashMap::new();
+                params.insert("max_length".to_string(), serde_json::json!(1000));
+                params.insert("check_sentiment".to_string(), serde_json::json!(true));
+                params
+            },
+        };
+
+        let serialized = serde_json::to_string(&config).expect("Should serialize");
+        let deserialized: ValidatorConfig = serde_json::from_str(&serialized).expect("Should deserialize");
+
+        assert_eq!(deserialized.name, config.name);
+        assert_eq!(deserialized.enabled, config.enabled);
+        assert_eq!(deserialized.priority, config.priority);
+        assert_eq!(deserialized.stages.len(), config.stages.len());
+        assert_eq!(deserialized.parameters["max_length"], 1000);
+        assert_eq!(deserialized.parameters["check_sentiment"], true);
+    }
+
+    #[tokio::test]
+    async fn validator_basic_functionality() {
+        let validator = TestValidator::new("test-validator");
+
+        // Test that validator contract is properly implemented
+        assert!(!validator.name().is_empty(), "Validator name should not be empty");
+        
+        let config = validator.config();
+        assert!(config.enabled, "Test validator should be enabled by default");
+        assert!(config.priority >= 0, "Priority should be non-negative");
+        assert!(!config.stages.is_empty(), "Validator should handle at least one stage");
+        
+        // Test that validator configuration is consistent
+        assert_eq!(validator.name(), config.name, "Validator name should match config name");
+    }
+
+    #[tokio::test]
+    async fn validator_should_validate_logic() {
+        let validator = TestValidator::new("test-validator");
+
+        let pre_execution_request = ValidationRequest {
+            agent_id: Uuid::new_v4(),
+            request_id: Uuid::new_v4(),
+            stage: ValidationStage::PreExecution,
+            content: ValidationContent::UserMessage {
+                message: "Test".to_string(),
+            },
+            context: HashMap::new(),
+        };
+
+        let post_tool_request = ValidationRequest {
+            stage: ValidationStage::PostTool,
+            ..pre_execution_request.clone()
+        };
+
+        // Should validate PreExecution (configured stage)
+        assert!(validator.should_validate(&pre_execution_request));
+        
+        // Should not validate PostTool (not configured)
+        assert!(!validator.should_validate(&post_tool_request));
+    }
+
+    #[tokio::test]
+    async fn validator_service_interface() {
+        let validator = TestValidator::new("test-validator");
+
+        // Test safe content validation logic
+        let safe_request = ValidationRequest {
+            agent_id: Uuid::new_v4(),
+            request_id: Uuid::new_v4(),
+            stage: ValidationStage::PreExecution,
+            content: ValidationContent::UserMessage {
+                message: "Hello world".to_string(),
+            },
+            context: HashMap::new(),
+        };
+
+        let response = validator.validate(safe_request).await;
+        assert!(response.is_ok(), "Validator should handle valid requests");
+        
+        let validation_response = response.expect("Validation should succeed");
+        assert!(validation_response.approved, "Safe content should be approved");
+        assert!(validation_response.reason.is_none(), "Approved content should not have rejection reason");
+        assert!(validation_response.modifications.is_none(), "Safe content should not need modifications");
+
+        // Test unsafe content detection and rejection
+        let unsafe_request = ValidationRequest {
+            agent_id: Uuid::new_v4(),
+            request_id: Uuid::new_v4(),
+            stage: ValidationStage::PreExecution,
+            content: ValidationContent::UserMessage {
+                message: "This is unsafe content".to_string(),
+            },
+            context: HashMap::new(),
+        };
+
+        let response = validator.validate(unsafe_request).await;
+        assert!(response.is_ok(), "Validator should handle unsafe content gracefully");
+        
+        let validation_response = response.expect("Validation should complete");
+        assert!(!validation_response.approved, "Unsafe content should be rejected");
+        assert!(validation_response.reason.is_some(), "Rejected content should include reason");
+        if let Some(reason) = validation_response.reason {
+            assert!(reason.contains("Unsafe content"), "Rejection reason should be specific");
+            assert!(!reason.is_empty(), "Reason should be descriptive");
+        }
+        
+        // Test validator consistency across multiple calls
+        let duplicate_safe_request = ValidationRequest {
+            agent_id: Uuid::new_v4(),
+            request_id: Uuid::new_v4(),
+            stage: ValidationStage::PreExecution,
+            content: ValidationContent::UserMessage {
+                message: "Hello world".to_string(), // Same safe message
+            },
+            context: HashMap::new(),
+        };
+        
+        let duplicate_response = validator.validate(duplicate_safe_request).await;
+        let duplicate_validation = duplicate_response.expect("Should validate consistently");
+        assert!(duplicate_validation.approved, "Validator should be consistent for same input");
+        
+        // Test different content types are handled
+        let tool_content_request = ValidationRequest {
+            agent_id: Uuid::new_v4(),
+            request_id: Uuid::new_v4(),
+            stage: ValidationStage::PreExecution,
+            content: ValidationContent::LlmResponse {
+                message: "AI response".to_string(),
+                tool_calls: vec![],
+            },
+            context: HashMap::new(),
+        };
+        
+        let tool_response = validator.validate(tool_content_request).await;
+        assert!(tool_response.is_ok(), "Validator should handle different content types");
+        let tool_validation = tool_response.expect("Should validate tool content");
+        assert!(tool_validation.approved, "Non-user content should have different validation rules");
+    }
+
+    #[tokio::test]
+    async fn validator_object_safety() {
+        // Test that we can create trait objects
+        let validator: Box<dyn Validator> = Box::new(TestValidator::new("boxed-validator"));
+
+        // Test that trait object methods work
+        let _name = validator.name();
+        let _config = validator.config();
+
+        let request = ValidationRequest {
+            agent_id: Uuid::new_v4(),
+            request_id: Uuid::new_v4(),
+            stage: ValidationStage::PreExecution,
+            content: ValidationContent::UserMessage {
+                message: "Test".to_string(),
+            },
+            context: HashMap::new(),
+        };
+
+        let _should_validate = validator.should_validate(&request);
+
+        // Test that we can store multiple validators in a collection
+        let validators: Vec<Box<dyn Validator>> = vec![
+            Box::new(TestValidator::new("validator1")),
+            Box::new(TestValidator::new("validator2")),
+        ];
+
+        assert_eq!(validators.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn validator_send_sync() {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+
+        assert_send::<Box<dyn Validator>>();
+        assert_sync::<Box<dyn Validator>>();
+
+        // Test that we can pass trait objects across thread boundaries
+        let validator: Box<dyn Validator> = Box::new(TestValidator::new("thread-test"));
+        let validator_name = validator.name().to_string();
+
+        tokio::spawn(async move {
+            let _name = validator.name();
+            // Validator trait object can be moved across threads
+        }).await.unwrap();
+
+        assert_eq!(validator_name, "thread-test");
+    }
+
+    #[test]
+    fn validation_modifications_structure() {
+        let modifications = ValidationModifications {
+            modified_content: "Updated content".to_string(),
+            blocked_tool_calls: vec!["tool1".to_string(), "tool2".to_string()],
+            added_warnings: vec!["Warning 1".to_string(), "Warning 2".to_string()],
+        };
+
+        // Should be cloneable
+        let cloned = modifications.clone();
+        assert_eq!(cloned.modified_content, modifications.modified_content);
+        assert_eq!(cloned.blocked_tool_calls.len(), 2);
+        assert_eq!(cloned.added_warnings.len(), 2);
+
+        // Should be debuggable
+        assert!(!format!("{:?}", modifications).is_empty());
+    }
+
+    #[test]
+    fn validation_stage_equality() {
+        assert_eq!(ValidationStage::PreExecution, ValidationStage::PreExecution);
+        assert_ne!(ValidationStage::PreExecution, ValidationStage::PostExecution);
+        
+        // Test that stages can be used in collections
+        let stages = [
+            ValidationStage::PreExecution,
+            ValidationStage::PostExecution,
+            ValidationStage::PostTool,
+            ValidationStage::PreResponse,
+        ];
+        
+        assert!(stages.contains(&ValidationStage::PreExecution));
+        assert!(stages.contains(&ValidationStage::PostTool));
+    }
+}
+
+/// Validator trait for request validation
+///
+/// Note: This trait is designed to be object-safe while still being compatible
+/// with Tower Service. Individual implementations can implement Service if needed,
+/// but the core trait focuses on the validation interface.
+#[async_trait]
+pub trait Validator: Send + Sync {
+    /// Validator name for identification
+    fn name(&self) -> &str;
+    
+    /// Validator configuration
+    fn config(&self) -> &ValidatorConfig;
+    
+    /// Whether this validator should run for the given request
+    fn should_validate(&self, request: &ValidationRequest) -> bool;
+    
+    /// Validate a request
+    async fn validate(&self, request: ValidationRequest) -> Result<ValidationResponse, PatinoxError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct ValidationRequest {
+    pub agent_id: Uuid,
+    pub request_id: Uuid,
+    pub stage: ValidationStage,
+    pub content: ValidationContent,
+    pub context: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ValidationStage {
+    PreExecution,   // Before LLM call
+    PostExecution,  // After LLM call, before tool execution
+    PostTool,       // After tool execution
+    PreResponse,    // Before sending response to user
+}
+
+#[derive(Debug, Clone)]
+pub enum ValidationContent {
+    UserMessage { message: String },
+    LlmResponse { message: String, tool_calls: Vec<crate::traits::tool::ToolCall> },
+    ToolResult { tool_name: String, result: crate::traits::tool::ToolResult },
+    FinalResponse { message: String },
+}
+
+#[derive(Debug, Clone)]
+pub struct ValidationResponse {
+    pub approved: bool,
+    pub reason: Option<String>,
+    pub modifications: Option<ValidationModifications>,
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ValidationModifications {
+    pub modified_content: String,
+    pub blocked_tool_calls: Vec<String>,
+    pub added_warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidatorConfig {
+    pub name: String,
+    pub enabled: bool,
+    pub priority: i32, // Lower numbers run first
+    pub stages: Vec<ValidationStage>,
+    pub parameters: HashMap<String, serde_json::Value>,
+}


### PR DESCRIPTION
- Fix critical mutex unwrap() panics with proper error handling in trait mocks
- Address clippy warning about vec! usage for static arrays
- Fix one true tautological test (agent_available_tools_list) to test contract requirements
- Update /review-tests command to distinguish legitimate mock testing from true tautologies
- Create comprehensive planning tasks for systematic test improvements
- Document discovery of mock testing vs tautological test distinction

Key insight: Most mock-based tests are legitimate when they exercise conditional logic. Only tests that verify hardcoded return values without logic are truly tautological.

🤖 Generated with [Claude Code](https://claude.ai/code)